### PR TITLE
:sparkles: Feat: 회원 JWT 토큰과 비회원 임시 토큰 발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     // Security
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -43,6 +48,10 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Apache StringUtils
+    implementation 'org.apache.commons:commons-lang3:3.17.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/dasi/typing/api/service/oauth/info/KakaoUserInfo.java
+++ b/src/main/java/dasi/typing/api/service/oauth/info/KakaoUserInfo.java
@@ -2,6 +2,7 @@ package dasi.typing.api.service.oauth.info;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import dasi.typing.domain.member.Member;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,5 +22,11 @@ public class KakaoUserInfo {
     this.sub = sub;
     this.name = name;
     this.nickname = nickname;
+  }
+
+  public Member toEntity() {
+    return Member.builder()
+        .kakaoId(sub)
+        .nickname(nickname).build();
   }
 }

--- a/src/main/java/dasi/typing/config/RedisConfig.java
+++ b/src/main/java/dasi/typing/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package dasi.typing.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.data.redis.port}")
+  private int redisPort;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(redisHost, redisPort);
+  }
+
+  @Bean
+  public RedisTemplate<String, String> redisTemplate() {
+    RedisTemplate<String, String> template = new RedisTemplate<>();
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    template.setConnectionFactory(redisConnectionFactory());
+
+    return template;
+  }
+}

--- a/src/main/java/dasi/typing/config/SecurityConfig.java
+++ b/src/main/java/dasi/typing/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package dasi.typing.config;
 
 import dasi.typing.api.service.oauth.CustomOAuth2UserService;
 import dasi.typing.handler.OAuth2AuthenticationSuccessHandler;
+import dasi.typing.jwt.GuestAuthenticationFilter;
+import dasi.typing.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +16,7 @@ import org.springframework.security.config.annotation.web.configurers.HttpBasicC
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -22,6 +25,8 @@ public class SecurityConfig {
 
   private final CustomOAuth2UserService customOAuth2UserService;
   private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final GuestAuthenticationFilter guestAuthenticationFilter;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -44,11 +49,13 @@ public class SecurityConfig {
             )
         );
 
+    http
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterAfter(guestAuthenticationFilter, JwtAuthenticationFilter.class);
+
     http.sessionManagement(
         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
     return http.build();
   }
-
-
 }

--- a/src/main/java/dasi/typing/domain/refreshToken/RefreshToken.java
+++ b/src/main/java/dasi/typing/domain/refreshToken/RefreshToken.java
@@ -1,0 +1,29 @@
+package dasi.typing.domain.refreshToken;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@RedisHash(value = "kakaoId", timeToLive = 60 * 60 * 24 * 7)
+public class RefreshToken {
+
+  @Id
+  @Indexed
+  private String kakaoId;
+
+  private String token;
+
+  @Builder
+  private RefreshToken(String kakaoId, String token) {
+    this.kakaoId = kakaoId;
+    this.token = token;
+  }
+
+  public RefreshToken updateValue(String refreshToken) {
+    this.token = refreshToken;
+    return this;
+  }
+}

--- a/src/main/java/dasi/typing/domain/refreshToken/RefreshTokenRepository.java
+++ b/src/main/java/dasi/typing/domain/refreshToken/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package dasi.typing.domain.refreshToken;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+  Optional<RefreshToken> findByKakaoId(String kakaoId);
+
+}

--- a/src/main/java/dasi/typing/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/dasi/typing/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,15 +1,31 @@
 package dasi.typing.handler;
 
+import dasi.typing.api.service.oauth.CustomOidcUser;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
+@RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final int TTL = 3;
+  private final String REDIRECT_URL = "/oauth/login";
+  private final String REDIS_KEY_PREFIX = "auth:temp-token:";
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 
   @Override
   public void onAuthenticationSuccess(
@@ -18,7 +34,28 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
       Authentication authentication
   ) throws IOException, ServletException {
 
-    response.sendRedirect("/");
+    CustomOidcUser customUser = (CustomOidcUser) authentication.getPrincipal();
+
+    String tempToken = UUID.randomUUID().toString();
+    String targetUrl = getTargetUrl(tempToken);
+
+    String kakaoId = customUser.getInfo().getSub();
+    String redisKey = REDIS_KEY_PREFIX + tempToken;
+    redisTemplate.opsForValue().set(
+        redisKey,
+        kakaoId,
+        TTL,
+        TimeUnit.MINUTES
+    );
+
+    redirectStrategy.sendRedirect(request, response, targetUrl);
+  }
+
+  private String getTargetUrl(String tempToken) {
+    return UriComponentsBuilder
+        .fromUriString(REDIRECT_URL)
+        .queryParam("success", tempToken)
+        .build().toUriString();
   }
 }
 

--- a/src/main/java/dasi/typing/jwt/GuestAuthenticationFilter.java
+++ b/src/main/java/dasi/typing/jwt/GuestAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package dasi.typing.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class GuestAuthenticationFilter extends OncePerRequestFilter {
+
+  private final String REDIS_KEY_PREFIX = "auth:temp-token:";
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+
+      String authHeader = request.getHeader("Authorization");
+
+      if (StringUtils.isEmpty(authHeader) || !StringUtils.startsWith(authHeader, "Bearer ")) {
+        String guestId = StringUtils.isNotEmpty(authHeader) ?
+            REDIS_KEY_PREFIX + authHeader : UUID.randomUUID().toString();
+
+        AnonymousAuthenticationToken anonymousToken = new AnonymousAuthenticationToken(
+            "guestKey",
+            new GuestPrincipal(guestId),
+            AuthorityUtils.createAuthorityList("GUEST")
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(anonymousToken);
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/dasi/typing/jwt/GuestPrincipal.java
+++ b/src/main/java/dasi/typing/jwt/GuestPrincipal.java
@@ -1,0 +1,12 @@
+package dasi.typing.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GuestPrincipal {
+
+  private final String id;
+
+}

--- a/src/main/java/dasi/typing/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/dasi/typing/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package dasi.typing.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  private static final String TOKEN_HEADER = "Authorization";
+  private static final String TOKEN_PREFIX = "Bearer ";
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String token = resolveToken(request);
+
+    if (StringUtils.isNotEmpty(token) && jwtTokenProvider.validateToken(token)) {
+
+      String kakaoId = jwtTokenProvider.getKakaoId(token);
+      List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("USER");
+
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(kakaoId, null, authorities);
+
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  public String resolveToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader(TOKEN_HEADER);
+
+    if (StringUtils.isNotEmpty(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
+      return bearerToken.substring(TOKEN_PREFIX.length());
+    }
+    return null;
+  }
+}

--- a/src/main/java/dasi/typing/jwt/JwtToken.java
+++ b/src/main/java/dasi/typing/jwt/JwtToken.java
@@ -1,0 +1,21 @@
+package dasi.typing.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class JwtToken {
+
+  private String grantType;
+
+  private String accessToken;
+
+  private String refreshToken;
+
+  @Builder
+  private JwtToken(String grantType, String accessToken, String refreshToken) {
+    this.grantType = grantType;
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  }
+}

--- a/src/main/java/dasi/typing/jwt/JwtTokenProvider.java
+++ b/src/main/java/dasi/typing/jwt/JwtTokenProvider.java
@@ -1,0 +1,115 @@
+package dasi.typing.jwt;
+
+import static dasi.typing.exception.Code.EMPTY_JWT_TOKEN;
+import static dasi.typing.exception.Code.EXPIRED_ACCESS_TOKEN;
+import static dasi.typing.exception.Code.INVALID_ACCESS_TOKEN;
+import static dasi.typing.exception.Code.UNSUPPORTED_JWT_TOKEN;
+
+import dasi.typing.domain.refreshToken.RefreshToken;
+import dasi.typing.domain.refreshToken.RefreshTokenRepository;
+import dasi.typing.exception.CustomException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+  private final Key key;
+  private static final String BEARER_TYPE = "Bearer";
+  private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 3;
+  private static final long TOKEN_REFRESH_TIME = 1000 * 60 * 60 * 24 * 7;
+
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  public JwtTokenProvider(@Value("${spring.jwt.secret}") String secretKey,
+      RefreshTokenRepository refreshTokenRepository) {
+    byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+    this.key = Keys.hmacShaKeyFor(keyBytes);
+    this.refreshTokenRepository = refreshTokenRepository;
+  }
+
+  public JwtToken generateToken(String kakaoId) {
+
+    Date now = new Date();
+    Date accessTokenExpiresIn = new Date(now.getTime() + TOKEN_EXPIRE_TIME);
+    Date refreshTokenExpiresIn = new Date(now.getTime() + TOKEN_REFRESH_TIME);
+
+    Claims claims = createClaims(kakaoId, now, accessTokenExpiresIn);
+
+    String accessToken = Jwts.builder()
+        .setClaims(claims)
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+
+    String refreshToken = Jwts.builder()
+        .setIssuedAt(now)
+        .setExpiration(refreshTokenExpiresIn)
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+
+    refreshTokenRepository.save(RefreshToken.builder()
+        .kakaoId(kakaoId)
+        .token(refreshToken).build());
+
+    return JwtToken.builder()
+        .grantType(BEARER_TYPE)
+        .accessToken(accessToken)
+        .refreshToken(refreshToken).build();
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+      return true;
+    } catch (SecurityException | MalformedJwtException e) {
+      throw new CustomException(INVALID_ACCESS_TOKEN);
+    } catch (ExpiredJwtException e) {
+      throw new CustomException(EXPIRED_ACCESS_TOKEN);
+    } catch (UnsupportedJwtException e) {
+      throw new CustomException(UNSUPPORTED_JWT_TOKEN);
+    } catch (IllegalArgumentException e) {
+      throw new CustomException(EMPTY_JWT_TOKEN);
+    }
+  }
+
+  public Claims getClaims(String token) {
+    try {
+      return Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(token).getBody();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
+    }
+  }
+
+  public String getKakaoId(final String token) {
+    return getClaims(token).get("kakaoId", String.class);
+  }
+
+  public String getRole(final String token) {
+    return getClaims(token).get("role", String.class);
+  }
+
+  private Claims createClaims(String kakaoId, Date now, Date accessTokenExpiresIn) {
+    Claims claims = Jwts.claims()
+        .setIssuer("typing")
+        .setSubject("KAKAO_ID")
+        .setIssuedAt(now)
+        .setExpiration(accessTokenExpiresIn);
+
+    claims.put("kakaoId", kakaoId);
+    claims.put("role", Role.USER);
+    return claims;
+  }
+}

--- a/src/main/java/dasi/typing/jwt/Role.java
+++ b/src/main/java/dasi/typing/jwt/Role.java
@@ -1,0 +1,12 @@
+package dasi.typing.jwt;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Role {
+
+  GUEST("비회원"), USER("회원");
+
+  private final String text;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,14 @@ spring:
       hibernate:
         format_sql: true
 
+  jwt:
+    secret: ${JWT_SECRET_KEY}
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   # Spring Security OAuth2, Client
   security:
     oauth2:
@@ -77,6 +85,14 @@ spring:
       hibernate:
         format_sql: true
     database-platform: org.hibernate.dialect.H2Dialect
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  jwt:
+    secret: ${JWT_SECRET_KEY}
 
   # Spring Security OAuth2, Client
   security:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#15 

## 📝 작업 내용

- JWT & Apache Lang3 StringUtils 의존성을 추가하였습니다. 
- JWT 토큰 및 임시 UUID 토큰을 임시로 저장하기 위해서 Redis In-Memory DB를 활용했습니다.
- Security 설정으로 JwtAuthenticationFilter -> GuestAuthenticationFilter 순서로 필터를 실행합니다.
- Filter를 통해서 회원과 비회원을 구분합니다. 
  - 회원인 경우 -> Access JWT 토큰을 필터링하여 활용합니다.
  - 비회원 경우 ->  Anonymous 토큰을 생성하여 활용합니다.

- 카카오 OAuth2 로그인에 성공했다면, Redirect와 함께 임시 토큰을 parameter로 전달합니다.
- 해당 임시 토큰을 활용하여 추후 회원가입 로직을 수행합니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

