### PR TITLE
:sparkles: Feat: 회원 로그인 및 회원가입 기능 구현

### DIFF
--- a/src/main/java/dasi/typing/api/controller/member/MemberController.java
+++ b/src/main/java/dasi/typing/api/controller/member/MemberController.java
@@ -1,0 +1,61 @@
+package dasi.typing.api.controller.member;
+
+import dasi.typing.api.controller.member.request.MemberCreateRequest;
+import dasi.typing.api.controller.member.request.MemberNicknameRequest;
+import dasi.typing.api.controller.member.response.NicknameResponse;
+import dasi.typing.api.service.member.MemberService;
+import dasi.typing.api.service.member.NicknameService;
+import dasi.typing.exception.ApiResponse;
+import dasi.typing.jwt.GuestPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('GUEST')")
+public class MemberController {
+
+  private final MemberService memberService;
+  private final NicknameService nicknameService;
+
+  @GetMapping("/api/v1/members")
+  public ResponseEntity<ApiResponse<Boolean>> signIn(
+      @AuthenticationPrincipal GuestPrincipal guest) {
+    String accessToken = memberService.signIn(guest.getId());
+    return ResponseEntity.ok()
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .body(ApiResponse.success(true));
+  }
+
+  @PostMapping("/api/v1/members")
+  public ResponseEntity<ApiResponse<Boolean>> signUp(
+      @AuthenticationPrincipal GuestPrincipal guest,
+      @RequestBody MemberCreateRequest request) {
+    String accessToken = memberService.signUp(guest.getId(), request.toServiceRequest());
+    return ResponseEntity.ok()
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .body(ApiResponse.success(true));
+  }
+
+  @PostMapping("/api/v1/members/nickname")
+  public ApiResponse<Boolean> validateNickname(@RequestBody MemberNicknameRequest request) {
+    memberService.validateNickname(request.toServiceRequest());
+    return ApiResponse.success(true);
+  }
+
+  @GetMapping("/api/v1/members/nickname/random")
+  public ApiResponse<NicknameResponse> generateRandomNickname() {
+    String nickname = nicknameService.generate();
+    return ApiResponse.success(NicknameResponse.builder()
+        .nickname(nickname).build());
+  }
+}

--- a/src/main/java/dasi/typing/api/controller/member/request/MemberCreateRequest.java
+++ b/src/main/java/dasi/typing/api/controller/member/request/MemberCreateRequest.java
@@ -1,0 +1,21 @@
+package dasi.typing.api.controller.member.request;
+
+import dasi.typing.api.service.member.request.MemberCreateServiceRequest;
+import dasi.typing.domain.consent.ConsentType;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class MemberCreateRequest {
+
+  private String nickname;
+
+  private List<ConsentType> agreements;
+
+  public MemberCreateServiceRequest toServiceRequest() {
+    return MemberCreateServiceRequest.builder()
+        .nickname(nickname)
+        .agreements(agreements).build();
+  }
+
+}

--- a/src/main/java/dasi/typing/api/controller/member/request/MemberNicknameRequest.java
+++ b/src/main/java/dasi/typing/api/controller/member/request/MemberNicknameRequest.java
@@ -1,0 +1,16 @@
+package dasi.typing.api.controller.member.request;
+
+import dasi.typing.api.service.member.request.MemberNicknameServiceRequest;
+import lombok.Getter;
+
+@Getter
+public class MemberNicknameRequest {
+
+  private String nickname;
+
+  public MemberNicknameServiceRequest toServiceRequest() {
+    return MemberNicknameServiceRequest.builder()
+        .nickname(nickname).build();
+  }
+
+}

--- a/src/main/java/dasi/typing/api/controller/member/request/MemberTokenResponse.java
+++ b/src/main/java/dasi/typing/api/controller/member/request/MemberTokenResponse.java
@@ -1,0 +1,14 @@
+package dasi.typing.api.controller.member.request;
+
+import lombok.Getter;
+
+@Getter
+public class MemberTokenResponse {
+
+  private final String accessToken;
+
+  public MemberTokenResponse(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+}

--- a/src/main/java/dasi/typing/api/controller/member/response/NicknameResponse.java
+++ b/src/main/java/dasi/typing/api/controller/member/response/NicknameResponse.java
@@ -1,0 +1,15 @@
+package dasi.typing.api.controller.member.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NicknameResponse {
+
+  private String nickname;
+
+  @Builder
+  private NicknameResponse(String nickname) {
+    this.nickname = nickname;
+  }
+}

--- a/src/main/java/dasi/typing/api/service/member/MemberService.java
+++ b/src/main/java/dasi/typing/api/service/member/MemberService.java
@@ -1,0 +1,104 @@
+package dasi.typing.api.service.member;
+
+import static dasi.typing.exception.Code.ALREADY_EXIST_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_CHARACTER_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_CV_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_LENGTH_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_TEMP_TOKEN;
+import static dasi.typing.exception.Code.KAKAO_ACCOUNT_NOT_REGISTERED;
+
+import dasi.typing.api.service.member.request.MemberCreateServiceRequest;
+import dasi.typing.api.service.member.request.MemberNicknameServiceRequest;
+import dasi.typing.domain.consent.Consent;
+import dasi.typing.domain.consent.ConsentRepository;
+import dasi.typing.domain.member.Member;
+import dasi.typing.domain.member.MemberRepository;
+import dasi.typing.domain.memberConsent.MemberConsent;
+import dasi.typing.exception.CustomException;
+import dasi.typing.jwt.JwtTokenProvider;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final MemberRepository memberRepository;
+  private final ConsentRepository consentRepository;
+  private final RedisTemplate<String, String> redisTemplate;
+
+  private static final Pattern INVALID_CV_PATTERN = Pattern.compile(".*[ㄱ-ㅎㅏ-ㅣ].*");
+  private static final Pattern ALLOWED_NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]+$");
+
+  public String signIn(String tempToken) {
+    String kakaoId = getKakaoIdFromTempToken(tempToken);
+    validateRegisteredMember(kakaoId);
+    return jwtTokenProvider.generateToken(kakaoId).getAccessToken();
+  }
+
+  @Transactional
+  public String signUp(String tempToken, MemberCreateServiceRequest request) {
+
+    String kakaoId = getKakaoIdFromTempToken(tempToken);
+    String nickname = request.getNickname();
+
+    Member member = Member.builder()
+        .kakaoId(kakaoId)
+        .nickname(nickname)
+        .build();
+
+    List<Consent> consents = consentRepository.findByTypeIn(request.getAgreements());
+
+    for (Consent consent : consents) {
+      MemberConsent memberConsent = MemberConsent.of(consent);
+      member.addConsent(memberConsent);
+    }
+
+    memberRepository.save(member);
+    return jwtTokenProvider.generateToken(kakaoId).getAccessToken();
+  }
+
+  public void validateNickname(MemberNicknameServiceRequest request) {
+
+    String nickname = request.getNickname();
+
+    if (StringUtils.isEmpty(nickname) || StringUtils.length(nickname) < 2
+        || StringUtils.length(nickname) > 12) {
+      throw new CustomException(INVALID_LENGTH_NICKNAME);
+    }
+    if (INVALID_CV_PATTERN.matcher(nickname).matches()) {
+      throw new CustomException(INVALID_CV_NICKNAME);
+    }
+    if (!ALLOWED_NICKNAME_PATTERN.matcher(nickname).matches()) {
+      throw new CustomException(INVALID_CHARACTER_NICKNAME);
+    }
+    if (validateAlreadyExistNickname(nickname)) {
+      throw new CustomException(ALREADY_EXIST_NICKNAME);
+    }
+  }
+
+  private String getKakaoIdFromTempToken(String tempToken) {
+    return Optional.ofNullable(redisTemplate.opsForValue().get(tempToken))
+        .orElseThrow(() -> new CustomException(INVALID_TEMP_TOKEN));
+  }
+
+  private boolean validateAlreadyExistNickname(String nickname) {
+    return memberRepository.existsByNickname(nickname);
+  }
+
+  private void validateRegisteredMember(String kakaoId) {
+    if (!memberRepository.existsByKakaoId(kakaoId)) {
+      throw new CustomException(KAKAO_ACCOUNT_NOT_REGISTERED);
+    }
+  }
+}

--- a/src/main/java/dasi/typing/api/service/member/NicknameService.java
+++ b/src/main/java/dasi/typing/api/service/member/NicknameService.java
@@ -1,0 +1,41 @@
+package dasi.typing.api.service.member;
+
+import java.text.MessageFormat;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NicknameService {
+
+  private final String[] ADJECTIVES = {
+      "사랑스러운", "희망찬", "행복한", "꿈같은", "빛나는", "기쁨넘치는", "여유넘치는", "이쁜미소의",
+      "용기가넘치는", "자존감높은", "평화로운", "자유로운", "활기찬", "반짝이는", "신나는", "즐거운",
+      "감사한", "응원하는", "환희하는", "환한", "긍정적인", "밝은", "따뜻한", "부드러운", "만족스러운",
+      "기운찬", "푸르른", "아름다운", "반가운", "멋진", "찬란한", "환상적인", "대단한", "특별한", "훈훈한",
+      "나아가는", "밝아지는", "힘이되는", "새롭게", "충만한", "활짝웃는", "화사한", "단단한", "멀리보는",
+      "여유로운", "기대되는", "노력하는", "끈기있는", "인내하는", "실천하는", "해내는", "강인한", "연습하는",
+      "열정있는", "흔들리지않는", "무저지지않는", "목표를이루는", "경험하는", "나아지는", "멈추지않는",
+      "극복하는", "최선을 다하는", "꾸준한", "성장하는", "발전하는", "도전하는", "성공하는", "배우는",
+      "익히는", "변화하는", "혁신적인", "창의적인", "열정적인", "호기심있는", "탐구적인", "도약하는",
+      "새로운", "깨닫는", "지혜로운", "스스로", "이끌어가는", "몰입하는", "목표하는", "자신을믿는"
+  };
+
+  private final String[] NOUNS = {
+      "인턴", "최종합격", "취준생", "성장러", "도전러", "배움러", "취뽀러", "밈마스터", "플렉서", "갓생러",
+      "엔잡러", "감성러", "텐션러", "소학행러", "카공러", "인사러", "코덕", "덕후러", "집콕러", "카페투어러",
+      "브이로그러", "짠테크러", "오운완러", "릴스러", "챌린저러", "갓생기록러", "덕질러"
+  };
+
+  private final Random RANDOM = new Random();
+
+
+  public String generate() {
+
+    String adjective = ADJECTIVES[RANDOM.nextInt(ADJECTIVES.length)];
+    String noun = NOUNS[RANDOM.nextInt(NOUNS.length)];
+
+    return MessageFormat.format("{0}{1}", adjective, noun);
+  }
+}

--- a/src/main/java/dasi/typing/api/service/member/request/MemberCreateServiceRequest.java
+++ b/src/main/java/dasi/typing/api/service/member/request/MemberCreateServiceRequest.java
@@ -1,0 +1,22 @@
+package dasi.typing.api.service.member.request;
+
+import dasi.typing.domain.consent.ConsentType;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public class MemberCreateServiceRequest {
+
+  private String nickname;
+
+  private List<ConsentType> agreements;
+
+  @Builder
+  private MemberCreateServiceRequest(String nickname, List<ConsentType> agreements) {
+    this.nickname = nickname;
+    this.agreements = agreements;
+  }
+}

--- a/src/main/java/dasi/typing/api/service/member/request/MemberNicknameServiceRequest.java
+++ b/src/main/java/dasi/typing/api/service/member/request/MemberNicknameServiceRequest.java
@@ -1,0 +1,15 @@
+package dasi.typing.api.service.member.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberNicknameServiceRequest {
+
+  private String nickname;
+
+  @Builder
+  private MemberNicknameServiceRequest(String nickname) {
+    this.nickname = nickname;
+  }
+}

--- a/src/main/java/dasi/typing/domain/consent/Consent.java
+++ b/src/main/java/dasi/typing/domain/consent/Consent.java
@@ -1,0 +1,23 @@
+package dasi.typing.domain.consent;
+
+import dasi.typing.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Consent extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  private ConsentType type;
+
+  private String description;
+
+}

--- a/src/main/java/dasi/typing/domain/consent/ConsentRepository.java
+++ b/src/main/java/dasi/typing/domain/consent/ConsentRepository.java
@@ -1,0 +1,12 @@
+package dasi.typing.domain.consent;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConsentRepository extends JpaRepository<Consent, Long> {
+
+  List<Consent> findByTypeIn(List<ConsentType> agreements);
+
+}

--- a/src/main/java/dasi/typing/domain/consent/ConsentType.java
+++ b/src/main/java/dasi/typing/domain/consent/ConsentType.java
@@ -1,0 +1,13 @@
+package dasi.typing.domain.consent;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ConsentType {
+
+  TERMS_OF_SERVICE("서비스 이용 약관"),
+  PRIVACY_POLICY("개인 정보 처리 방침");
+
+  private final String text;
+
+}

--- a/src/main/java/dasi/typing/domain/member/Member.java
+++ b/src/main/java/dasi/typing/domain/member/Member.java
@@ -1,10 +1,17 @@
 package dasi.typing.domain.member;
 
 import dasi.typing.domain.BaseEntity;
+import dasi.typing.domain.memberConsent.MemberConsent;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,13 +26,23 @@ public class Member extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Column(unique = true)
   private String kakaoId;
 
+  @Column(unique = true)
   private String nickname;
+
+  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "member_id")
+  private List<MemberConsent> agreements = new ArrayList<>();
 
   @Builder
   private Member(String kakaoId, String nickname) {
     this.kakaoId = kakaoId;
     this.nickname = nickname;
+  }
+
+  public void addConsent(MemberConsent memberConsent) {
+    agreements.add(memberConsent);
   }
 }

--- a/src/main/java/dasi/typing/domain/member/MemberRepository.java
+++ b/src/main/java/dasi/typing/domain/member/MemberRepository.java
@@ -6,4 +6,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+  boolean existsByKakaoId(String kakaoId);
+
+  boolean existsByNickname(String nickname);
+
 }

--- a/src/main/java/dasi/typing/domain/memberConsent/MemberConsent.java
+++ b/src/main/java/dasi/typing/domain/memberConsent/MemberConsent.java
@@ -1,0 +1,38 @@
+package dasi.typing.domain.memberConsent;
+
+import dasi.typing.domain.BaseEntity;
+import dasi.typing.domain.consent.Consent;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class MemberConsent extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "consent_id")
+  private Consent consent;
+
+  private final boolean agreed = true;
+
+  @Builder
+  private MemberConsent(Consent consent) {
+    this.consent = consent;
+  }
+
+  public static MemberConsent of(Consent consent) {
+    return MemberConsent.builder()
+        .consent(consent).build();
+  }
+}

--- a/src/main/java/dasi/typing/domain/memberConsent/MemberConsentRepository.java
+++ b/src/main/java/dasi/typing/domain/memberConsent/MemberConsentRepository.java
@@ -1,0 +1,9 @@
+package dasi.typing.domain.memberConsent;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberConsentRepository extends JpaRepository<MemberConsent, Long> {
+
+}

--- a/src/main/java/dasi/typing/exception/ApiResponse.java
+++ b/src/main/java/dasi/typing/exception/ApiResponse.java
@@ -19,11 +19,11 @@ public class ApiResponse<T> {
         .data(data).build();
   }
 
-  public static ApiResponse<Void> error(Code errorCode) {
-    return new ApiResponseBuilder<Void>()
+  public static ApiResponse<Boolean> error(Code errorCode) {
+    return new ApiResponseBuilder<Boolean>()
         .code(errorCode.getCode())
         .message(errorCode.getMessage())
-        .data(null).build();
+        .data(false).build();
   }
 
 }

--- a/src/main/java/dasi/typing/exception/Code.java
+++ b/src/main/java/dasi/typing/exception/Code.java
@@ -10,17 +10,30 @@ public enum Code {
   // SUCCESS
   OK(0, "success"),
 
-  // ID, PW
+  // Nickname
   INVALID_LENGTH_NICKNAME(1000, "띄어쓰기 없이 2자 ~ 12자까지 가능해요."),
   INVALID_CV_NICKNAME(1001, "자음, 모음은 닉네임 설정 불가합니다."),
   INVALID_CHARACTER_NICKNAME(1002, "한글, 영문, 숫자만 입력해주세요."),
-  ALREADY_NICKNAME_EXIST(1003, "이미 사용중인 닉네임이에요."),
+  ALREADY_EXIST_NICKNAME(1003, "이미 사용중인 닉네임이에요."),
 
   // Phrase
   NOT_EXIST_PHRASE(2000, "해당 문장이 존재하지 않습니다."),
 
-  // Kakao
-  KAKAO_ACCOUNT_NOT_FOUND(3000, "Kakao 사용자 정보를 가져오는데 실패했습니다.");
+  // Member & Kakao OAuth2
+  ALREADY_EXIST_MEMBER(3000, "이미 존재하는 유저입니다."),
+  KAKAO_ACCOUNT_NOT_FOUND(3001, "Kakao 사용자 정보를 가져오는데 실패했습니다."),
+  KAKAO_ACCOUNT_NOT_REGISTERED(3002, "카카오 계정이 등록되어 있지 않습니다. 회원가입이 필요합니다."),
+
+  // Temp Token
+  INVALID_TEMP_TOKEN(4000, "유효하지 않은 임시 토큰입니다."),
+
+  // JWT Token
+  INVALID_ACCESS_TOKEN(5000, "유효하지 않은 ACCESS_JWT 서명입니다."),
+  EXPIRED_ACCESS_TOKEN(5001, "만료된 ACCESS_JWT 토큰입니다."),
+  INVALID_REFRESH_TOKEN(5002, "유효하지 않은 REFRESH_JWT 서명입니다."),
+  EXPIRED_REFRESH_TOKEN(5003, "만료된 REFRESH_JWT 토큰입니다."),
+  UNSUPPORTED_JWT_TOKEN(5004, "지원되지 않는 JWT 토큰 형식입니다."),
+  EMPTY_JWT_TOKEN(5005, "토큰이 비어있거나 제공되지 않았습니다.");
 
   private final Integer code;
   private final String message;

--- a/src/main/java/dasi/typing/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dasi/typing/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package dasi.typing.exception;
 
+import static dasi.typing.exception.Code.*;
+
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -7,8 +10,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
   @ExceptionHandler(CustomException.class)
-  protected ApiResponse<Void> handleException(CustomException e) {
+  protected ApiResponse<Boolean> handleException(CustomException e) {
     return ApiResponse.error(e.getErrorCode());
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  protected ApiResponse<Boolean> handleException(DataIntegrityViolationException e) {
+    return ApiResponse.error(ALREADY_EXIST_MEMBER);
   }
 
 }

--- a/src/test/java/dasi/typing/api/service/member/MemberServiceTest.java
+++ b/src/test/java/dasi/typing/api/service/member/MemberServiceTest.java
@@ -1,0 +1,92 @@
+package dasi.typing.api.service.member;
+
+import static dasi.typing.domain.consent.ConsentType.PRIVACY_POLICY;
+import static dasi.typing.domain.consent.ConsentType.TERMS_OF_SERVICE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dasi.typing.api.service.member.request.MemberCreateServiceRequest;
+import dasi.typing.domain.member.MemberRepository;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MemberServiceTest {
+
+  @Autowired
+  private MemberService memberService;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private RedisTemplate<String, String> redisTemplate;
+
+  @AfterEach
+  void tearDown() {
+    memberRepository.deleteAllInBatch();
+  }
+
+  @Test
+  @DisplayName("동시에 같은 닉네임으로 요청하면 1명만 성공한다")
+  void nicknameConcurrency() throws Exception {
+    // given
+    int threadCount = 100;
+    String nickname = "닉네임";
+    String tempToken = UUID.randomUUID().toString();
+    String kakaoId = "0000000000";
+
+    saveKakaoIdInRedis(tempToken, kakaoId);
+
+    CountDownLatch latch = new CountDownLatch(threadCount);
+    AtomicInteger successCount = new AtomicInteger(0);
+    AtomicInteger failedCount = new AtomicInteger(0);
+
+    MemberCreateServiceRequest request = MemberCreateServiceRequest.builder()
+        .nickname(nickname)
+        .agreements(List.of(TERMS_OF_SERVICE, PRIVACY_POLICY)).build();
+
+    // when
+    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+    for (int i = 0; i < threadCount; i++) {
+      executorService.submit(() -> {
+        try {
+          memberService.signUp(tempToken, request);
+          successCount.incrementAndGet();
+        } catch (DataIntegrityViolationException e) {
+          failedCount.incrementAndGet();
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+    latch.await();
+    executorService.shutdown();
+
+    // then
+    assertThat(successCount.get()).isEqualTo(1);
+    assertThat(failedCount.get()).isEqualTo(threadCount - 1);
+  }
+
+  private void saveKakaoIdInRedis(String tempToken, String kakaoId) {
+    redisTemplate.opsForValue().set(
+        tempToken,
+        kakaoId,
+        10,
+        TimeUnit.SECONDS
+    );
+  }
+}

--- a/src/test/java/dasi/typing/api/service/member/NicknameServiceTest.java
+++ b/src/test/java/dasi/typing/api/service/member/NicknameServiceTest.java
@@ -1,0 +1,28 @@
+package dasi.typing.api.service.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NicknameServiceTest {
+
+  @Autowired
+  private NicknameService nicknameService;
+
+  @Test
+  @DisplayName("랜덤으로 생성한 두 닉네임은 서로 다르다.")
+  void generateRandomNickname() {
+    // given
+    String nickname1 = nicknameService.generate();
+    String nickname2 = nicknameService.generate();
+
+    // when & then
+    assertThat(nickname1).isNotEqualTo(nickname2);
+  }
+}

--- a/src/test/java/dasi/typing/exception/ApiResponseTest.java
+++ b/src/test/java/dasi/typing/exception/ApiResponseTest.java
@@ -37,7 +37,7 @@ class ApiResponseTest {
     Code errorCode = Code.INVALID_CHARACTER_NICKNAME;
 
     // when
-    ApiResponse<Void> response = ApiResponse.error(errorCode);
+    ApiResponse<Boolean> response = ApiResponse.error(errorCode);
 
     // then
     assertThat(response)
@@ -45,7 +45,7 @@ class ApiResponseTest {
         .containsExactly(
             Code.INVALID_CHARACTER_NICKNAME.getCode(),
             Code.INVALID_CHARACTER_NICKNAME.getMessage(),
-            null
+            false
         );
   }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#16 

## 📝 작업 내용
- 회원가입 시, 선택한 약관 동의 항목 내용을 저장하기 위해서 Consent, MemberConsent Entity를 구현했습니다.
- MemberConsent 라는 중간 Table을 만들어 Member, Consent 관계를 1:N, M:1 관계로 풀어서 구현했습니다.
- 이를 바탕으로 로그인, 회원가입 기능 로직을 구현했습니다.
- 랜덤 닉네임 생성 기능 및 닉네임 검증 기능을 구현했습니다.
- 유일한 유저 생성을 위한 Unique 테스트, 랜덤 닉네임 생성 테스트를 진행했습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

