### PR TITLE
:sparkles: Feat: 저장되어있는 문장 중 임의의 20개 문장 조회 기능 구현

### DIFF
--- a/src/main/java/dasi/typing/api/controller/phrase/PhraseController.java
+++ b/src/main/java/dasi/typing/api/controller/phrase/PhraseController.java
@@ -1,0 +1,26 @@
+package dasi.typing.api.controller.phrase;
+
+import dasi.typing.api.controller.phrase.response.PhraseResponse;
+import dasi.typing.api.service.phrase.PhraseService;
+import dasi.typing.exception.ApiResponse;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyRole('USER', 'GUEST')")
+public class PhraseController {
+
+  private final PhraseService phraseService;
+
+  @GetMapping("/api/v1/phrases")
+  public ApiResponse<Map<String, List<PhraseResponse>>> getRandomPhrases() {
+    List<PhraseResponse> responses = phraseService.getRandomPhrases();
+    return ApiResponse.success("phrases", responses);
+  }
+
+}

--- a/src/main/java/dasi/typing/api/controller/phrase/response/PhraseResponse.java
+++ b/src/main/java/dasi/typing/api/controller/phrase/response/PhraseResponse.java
@@ -1,0 +1,38 @@
+package dasi.typing.api.controller.phrase.response;
+
+import dasi.typing.domain.phrase.Phrase;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PhraseResponse {
+
+  private Long id;
+  private String sentence;
+  private String title;
+  private String author;
+  private String lang;
+  private String type;
+
+  @Builder
+  private PhraseResponse(Long id, String sentence, String title, String author, String lang,
+      String type) {
+    this.id = id;
+    this.sentence = sentence;
+    this.title = title;
+    this.author = author;
+    this.lang = lang;
+    this.type = type;
+  }
+
+  public static PhraseResponse from(Phrase phrase) {
+    return PhraseResponse.builder()
+        .id(phrase.getId())
+        .sentence(phrase.getSentence())
+        .title(phrase.getTitle())
+        .author(phrase.getAuthor())
+        .lang(phrase.getLang().name())
+        .type(phrase.getType().name())
+        .build();
+  }
+}

--- a/src/main/java/dasi/typing/api/service/phrase/PhraseService.java
+++ b/src/main/java/dasi/typing/api/service/phrase/PhraseService.java
@@ -1,0 +1,19 @@
+package dasi.typing.api.service.phrase;
+
+import dasi.typing.api.controller.phrase.response.PhraseResponse;
+import dasi.typing.domain.phrase.PhraseRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PhraseService {
+
+  private final PhraseRepository phraseRepository;
+
+  public List<PhraseResponse> getRandomPhrases() {
+    return phraseRepository.getRandom20Phrases()
+        .stream().map(PhraseResponse::from).toList();
+  }
+}

--- a/src/main/java/dasi/typing/domain/phrase/Phrase.java
+++ b/src/main/java/dasi/typing/domain/phrase/Phrase.java
@@ -31,15 +31,15 @@ public class Phrase extends BaseEntity {
   private Lang lang;
 
   @Enumerated(EnumType.STRING)
-  private LangType types;
+  private LangType type;
 
   @Builder
-  private Phrase(String sentence, String title, String author, Lang lang, LangType types) {
+  private Phrase(String sentence, String title, String author, Lang lang, LangType type) {
     this.sentence = sentence;
     this.title = title;
     this.author = author;
     this.lang = lang;
-    this.types = types;
+    this.type = type;
   }
 
 }

--- a/src/main/java/dasi/typing/domain/phrase/PhraseRepository.java
+++ b/src/main/java/dasi/typing/domain/phrase/PhraseRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface PhraseRepository extends JpaRepository<Phrase, Long> {
 
   @Query("SELECT p FROM Phrase p ORDER BY FUNCTION('RAND') LIMIT 20")
-  List<Phrase> findRandom20Phrases();
+  List<Phrase> getRandom20Phrases();
 
 }

--- a/src/main/java/dasi/typing/exception/ApiResponse.java
+++ b/src/main/java/dasi/typing/exception/ApiResponse.java
@@ -1,5 +1,6 @@
 package dasi.typing.exception;
 
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,13 @@ public class ApiResponse<T> {
         .code(Code.OK.getCode())
         .message(Code.OK.getMessage())
         .data(data).build();
+  }
+
+  public static <T> ApiResponse<Map<String, T>> success(String key, T data) {
+    return new ApiResponseBuilder<Map<String, T>>()
+        .code(Code.OK.getCode())
+        .message(Code.OK.getMessage())
+        .data(Map.of(key, data)).build();
   }
 
   public static ApiResponse<Boolean> error(Code errorCode) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,9 @@ spring:
               - profile_nickname    # 닉네임
               - account_email       # 카카오계정(이메일)
 
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
 ---
 spring:
   # Profile Config
@@ -118,6 +121,10 @@ spring:
               - profile_nickname    # 닉네임
               - account_email       # 카카오계정(이메일)
               - openid              # OIDC
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+
 
 logging:
   level:

--- a/src/test/java/dasi/typing/domain/phrase/PhraseRepositoryTest.java
+++ b/src/test/java/dasi/typing/domain/phrase/PhraseRepositoryTest.java
@@ -29,17 +29,17 @@ class PhraseRepositoryTest {
     // given
     List<Phrase> phrases = new ArrayList<>();
     for (int i = 1; i <= 25; i++) {
-      phrases.add(createPhrase(String.valueOf(i), "문장 " + i, "작가 " + i, Lang.KO, LangType.QUOTE));
+      phrases.add(createPhrase(String.valueOf(i), "문장 " + i, "작가 " + i));
     }
     phraseRepository.saveAll(phrases);
 
     // when
     List<Long> allIds = phrases.stream().map(Phrase::getId).toList();
 
-    List<Long> firstResult = phraseRepository.findRandom20Phrases()
+    List<Long> firstResult = phraseRepository.getRandom20Phrases()
         .stream().map(Phrase::getId).toList();
 
-    List<Long> secondResult = phraseRepository.findRandom20Phrases()
+    List<Long> secondResult = phraseRepository.getRandom20Phrases()
         .stream().map(Phrase::getId).toList();
 
     // then
@@ -53,14 +53,13 @@ class PhraseRepositoryTest {
         .isNotEqualTo(secondResult);
   }
 
-  private Phrase createPhrase(String sentence, String title, String author, Lang lang,
-      LangType types) {
+  private Phrase createPhrase(String sentence, String title, String author) {
     return Phrase.builder()
         .sentence(sentence)
         .title(title)
         .author(author)
-        .lang(lang)
-        .types(types)
+        .lang(Lang.KO)
+        .type(LangType.QUOTE)
         .build();
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#19 

## 📝 작업 내용

- 응답 객체 필드변수의 네이밍 전략을 전역으로 SNAKE_CASE 형태로 변경할 수 있도록 application.yml 파일을 수정하였습니다.
- 공통 응답 메소드를 오버로딩하여 보다 유연한 응답을 반환할 수 있도록 ApiResponse 클래스 파일을 수정하였습니다.
- Jpa Repository 쿼리 메소드를 활용하여 저장되어 있는 문장 중 무작위로 20개 문장을 조회할 수 있는 기능을 구현했습니다.
- 무작위로 20개의 문장을 가져올 수 있는지에 대한 테스트를 진행했습니다.
<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

