### PR TITLE
:sparkles: Feat: 타자 결과에 대한 점수 공식 적용 및 순위 조회 기능 구현

### DIFF
--- a/src/main/java/dasi/typing/api/controller/ranking/RankingController.java
+++ b/src/main/java/dasi/typing/api/controller/ranking/RankingController.java
@@ -4,30 +4,29 @@ import dasi.typing.api.controller.ranking.response.RankingResponse;
 import dasi.typing.api.service.ranking.RankingService;
 import dasi.typing.exception.ApiResponse;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@PreAuthorize("hasAnyRole('USER', 'GUEST')")
 public class RankingController {
 
   private final RankingService rankingService;
 
   @GetMapping("/api/v1/rankings/realtime")
-  public ApiResponse<List<RankingResponse>> getRealTimeRanking() {
-
+  public ApiResponse<Map<String, List<RankingResponse>>> getRealTimeRanking() {
     List<RankingResponse> responses = rankingService.getRealTimeRanking();
-
-    return ApiResponse.success(responses);
+    return ApiResponse.success("rankings", responses);
   }
 
   @GetMapping("/api/v1/rankings/monthly")
-  public ApiResponse<List<RankingResponse>> getMonthlyRanking() {
-
+  public ApiResponse<Map<String, List<RankingResponse>>> getMonthlyRanking() {
     List<RankingResponse> responses = rankingService.getMonthlyRanking();
-
-    return ApiResponse.success(responses);
+    return ApiResponse.success("rankings", responses);
   }
 
 }

--- a/src/main/java/dasi/typing/api/controller/ranking/response/RankingResponse.java
+++ b/src/main/java/dasi/typing/api/controller/ranking/response/RankingResponse.java
@@ -1,5 +1,6 @@
 package dasi.typing.api.controller.ranking.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -17,6 +18,7 @@ public class RankingResponse {
 
   private Integer score;
 
+  @JsonIgnore
   private LocalDateTime createdDate;
 
   private Long ranking;

--- a/src/main/java/dasi/typing/api/controller/typing/request/TypingCreateRequest.java
+++ b/src/main/java/dasi/typing/api/controller/typing/request/TypingCreateRequest.java
@@ -14,12 +14,15 @@ public class TypingCreateRequest {
 
   private Integer wpm;
 
+  private Integer maxCpm;
+
   @Builder
-  private TypingCreateRequest(Long phraseId, Integer cpm, Integer acc, Integer wpm) {
+  private TypingCreateRequest(Long phraseId, Integer cpm, Integer acc, Integer wpm, Integer maxCpm) {
     this.phraseId = phraseId;
     this.cpm = cpm;
     this.acc = acc;
     this.wpm = wpm;
+    this.maxCpm = maxCpm;
   }
 
   public TypingCreateServiceRequest toServiceRequest() {
@@ -27,6 +30,7 @@ public class TypingCreateRequest {
         .phraseId(phraseId)
         .cpm(cpm)
         .acc(acc)
-        .wpm(wpm).build();
+        .wpm(wpm)
+        .maxCpm(maxCpm).build();
   }
 }

--- a/src/main/java/dasi/typing/api/service/typing/request/TypingCreateServiceRequest.java
+++ b/src/main/java/dasi/typing/api/service/typing/request/TypingCreateServiceRequest.java
@@ -3,12 +3,13 @@ package dasi.typing.api.service.typing.request;
 import dasi.typing.domain.member.Member;
 import dasi.typing.domain.phrase.Phrase;
 import dasi.typing.domain.typing.Typing;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TypingCreateServiceRequest {
 
   private Long phraseId;
@@ -19,12 +20,16 @@ public class TypingCreateServiceRequest {
 
   private Integer wpm;
 
+  private Integer maxCpm;
+
   @Builder
-  private TypingCreateServiceRequest(Long phraseId, Integer cpm, Integer acc, Integer wpm) {
+  private TypingCreateServiceRequest(Long phraseId, Integer cpm, Integer acc, Integer wpm,
+      Integer maxCpm) {
     this.phraseId = phraseId;
     this.cpm = cpm;
     this.acc = acc;
     this.wpm = wpm;
+    this.maxCpm = maxCpm;
   }
 
   public Typing toEntity(Phrase phrase, Member member) {
@@ -33,6 +38,7 @@ public class TypingCreateServiceRequest {
         .phrase(phrase)
         .cpm(cpm)
         .acc(acc)
-        .wpm(wpm).build();
+        .wpm(wpm)
+        .maxCpm(maxCpm).build();
   }
 }

--- a/src/main/java/dasi/typing/domain/typing/Typing.java
+++ b/src/main/java/dasi/typing/domain/typing/Typing.java
@@ -29,7 +29,9 @@ public class Typing extends BaseEntity {
 
   private Integer wpm;
 
-  private Integer maxWpm;
+  private Integer maxCpm;
+
+  private Integer score;
 
   @ManyToOne(fetch = FetchType.LAZY)
   private Member member;
@@ -38,11 +40,30 @@ public class Typing extends BaseEntity {
   private Phrase phrase;
 
   @Builder
-  private Typing(Integer cpm, Integer acc, Integer wpm, Member member, Phrase phrase) {
+  private Typing(Integer cpm, Integer acc, Integer wpm, Integer maxCpm, Member member,
+      Phrase phrase) {
     this.cpm = cpm;
     this.acc = acc;
     this.wpm = wpm;
+    this.maxCpm = maxCpm;
+    this.score = calculateScore();
     this.member = member;
     this.phrase = phrase;
+  }
+
+  public int calculateScore() {
+    double penalty = getPenaltyRate(acc);
+    return (int) Math.round(cpm * (1 - penalty));
+  }
+
+  private double getPenaltyRate(int accuracy) {
+    if (accuracy >= 90) return 0.0;
+    if (accuracy >= 40) return 0.9 - (double) accuracy / 100;
+    if (accuracy >= 35) return 0.60;
+    if (accuracy >= 30) return 0.70;
+    if (accuracy >= 25) return 0.80;
+    if (accuracy >= 20) return 0.90;
+    if (accuracy >= 10) return 0.97;
+    return 1.0;
   }
 }

--- a/src/main/java/dasi/typing/domain/typing/TypingRepository.java
+++ b/src/main/java/dasi/typing/domain/typing/TypingRepository.java
@@ -12,9 +12,9 @@ public interface TypingRepository extends JpaRepository<Typing, Integer> {
   @Query(value = """
       SELECT t.member_id AS memberId, 
              m.nickname AS nickname,
-             t.wpm AS score,
-             t.created_date AS createdDate,
-             ROW_NUMBER() OVER (ORDER BY t.wpm DESC, t.max_wpm DESC, t.acc DESC, t.id) AS ranking
+             t.score AS score,
+             t.created_date,
+             ROW_NUMBER() OVER (ORDER BY t.score DESC, t.max_cpm DESC, t.acc DESC, t.created_date, t.id) AS ranking
       FROM typing t
       JOIN member m ON t.member_id = m.id
       ORDER BY ranking ASC
@@ -25,9 +25,9 @@ public interface TypingRepository extends JpaRepository<Typing, Integer> {
   @Query(value = """
       SELECT t.member_id AS memberId, 
              m.nickname AS nickname,
-             t.wpm AS score,
-             t.created_date AS createdDate,
-             ROW_NUMBER() OVER (ORDER BY t.wpm DESC, t.max_wpm DESC, t.acc DESC, t.id) AS ranking
+             t.score AS score,
+             t.created_date,
+             ROW_NUMBER() OVER (ORDER BY t.score DESC, t.max_cpm DESC, t.acc DESC, t.created_date, t.id) AS ranking
       FROM typing t
       JOIN member m ON t.member_id = m.id
       WHERE t.created_date BETWEEN :startDate AND :endDate
@@ -38,4 +38,17 @@ public interface TypingRepository extends JpaRepository<Typing, Integer> {
       @Param("startDate") LocalDateTime startDate,
       @Param("endDate") LocalDateTime endDate
   );
+
+  @Query(value = """
+      SELECT r.ranking
+      FROM (
+          SELECT t.id,
+                 ROW_NUMBER() OVER (ORDER BY t.score DESC, t.max_cpm DESC, t.acc DESC, t.created_date, t.id) AS ranking
+          FROM typing t
+      ) r
+      WHERE r.id = :typingId
+      """, nativeQuery = true)
+  int findTypingRank(@Param("typingId") Long typingId);
+
+
 }

--- a/src/test/java/dasi/typing/domain/typing/TypingTest.java
+++ b/src/test/java/dasi/typing/domain/typing/TypingTest.java
@@ -1,0 +1,54 @@
+package dasi.typing.domain.typing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TypingTest {
+
+  @ParameterizedTest
+  @DisplayName("정확도 공식에 따라서 최종 타수를 계산할 수 있다.")
+  @MethodSource("paramsForCalculateFinalScore")
+  void calculateFinalScore(int cpm, int acc, int expect) {
+    // given
+    Typing typing = createTyping(cpm, acc);
+
+    // when
+    int result = typing.getScore();
+
+    // then
+    assertEquals(expect, result);
+  }
+
+  private Typing createTyping(int cpm, int acc) {
+    return Typing.builder()
+        .cpm(cpm)
+        .acc(acc)
+        .wpm(0)
+        .member(null)
+        .phrase(null).build();
+  }
+
+  private static Stream<Arguments> paramsForCalculateFinalScore() {
+    return Stream.of(
+        Arguments.of(300, 95, 300),
+        Arguments.of(300, 89, 297),
+        Arguments.of(300, 75, 255),
+        Arguments.of(300, 60, 210),
+        Arguments.of(300, 50, 180),
+        Arguments.of(300, 39, 120),
+        Arguments.of(300, 30, 90),
+        Arguments.of(300, 25, 60),
+        Arguments.of(300, 20, 30),
+        Arguments.of(300, 15, 9),
+        Arguments.of(300, 5, 0)
+    );
+  }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#19 

## 📝 작업 내용

- 타자 결과에 대한 점수 공식을 적용하여 타자 연습을 한 유저가 종합 점수를 얻을 수 있는 기능을 구현했습니다.
- 유저의 종합 점수들을 토대로 순위를 조회할 수 있는 기능을 수정 및 구현하였습니다.
- 타자 결과에 대한 점수 공식이 정확한 점수를 반환할 수 있는지 매개변수 테스트를 진행했습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

