### PR TITLE
:sparkles: Feat: 회원 AccessToken 만료 시, RefreshToken 활용한 재발급 및 재로그인 유도 기능 구현

### DIFF
--- a/src/main/java/dasi/typing/api/controller/member/MemberController.java
+++ b/src/main/java/dasi/typing/api/controller/member/MemberController.java
@@ -8,17 +8,17 @@ import dasi.typing.api.service.member.NicknameService;
 import dasi.typing.exception.ApiResponse;
 import dasi.typing.jwt.GuestPrincipal;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @PreAuthorize("hasRole('GUEST')")
@@ -57,5 +57,17 @@ public class MemberController {
     String nickname = nicknameService.generate();
     return ApiResponse.success(NicknameResponse.builder()
         .nickname(nickname).build());
+  }
+
+  @PostMapping("/api/v1/members/reissue")
+  @PreAuthorize("hasRole('USER')")
+  public ResponseEntity<ApiResponse<Boolean>> reissue() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String kakaoId = (String) authentication.getPrincipal();
+
+    String accessToken = memberService.reissue(kakaoId);
+    return ResponseEntity.ok()
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .body(ApiResponse.success(true));
   }
 }

--- a/src/main/java/dasi/typing/api/controller/typing/TypingController.java
+++ b/src/main/java/dasi/typing/api/controller/typing/TypingController.java
@@ -7,6 +7,8 @@ import dasi.typing.exception.ApiResponse;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +23,8 @@ public class TypingController {
   @PostMapping("/api/v1/typings")
   public ApiResponse<Map<String, TypingResponse>> saveTyping(
       @RequestBody TypingCreateRequest request) {
-    TypingResponse response = typingService.saveTyping(request.toServiceRequest());
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    TypingResponse response = typingService.saveTyping(authentication, request.toServiceRequest());
     return ApiResponse.success("typing", response);
   }
 }

--- a/src/main/java/dasi/typing/api/service/phrase/LuckyMessageService.java
+++ b/src/main/java/dasi/typing/api/service/phrase/LuckyMessageService.java
@@ -2,9 +2,11 @@ package dasi.typing.api.service.phrase;
 
 
 import java.util.Random;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+@Getter
 @Service
 @RequiredArgsConstructor
 public class LuckyMessageService {

--- a/src/main/java/dasi/typing/api/service/typing/TypingService.java
+++ b/src/main/java/dasi/typing/api/service/typing/TypingService.java
@@ -7,16 +7,15 @@ import dasi.typing.api.service.typing.request.TypingCreateServiceRequest;
 import dasi.typing.api.service.typing.response.TypingResponse;
 import dasi.typing.domain.member.Member;
 import dasi.typing.domain.member.MemberRepository;
+import dasi.typing.domain.member.Role;
 import dasi.typing.domain.phrase.Phrase;
 import dasi.typing.domain.phrase.PhraseRepository;
 import dasi.typing.domain.typing.Typing;
 import dasi.typing.domain.typing.TypingRepository;
 import dasi.typing.exception.Code;
 import dasi.typing.exception.CustomException;
-import dasi.typing.domain.member.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,14 +30,13 @@ public class TypingService {
   private final LuckyMessageService luckyMessageService;
 
   @Transactional
-  public TypingResponse saveTyping(TypingCreateServiceRequest request) {
+  public TypingResponse saveTyping(Authentication authentication, TypingCreateServiceRequest request) {
 
     Long phraseId = request.getPhraseId();
     Phrase phrase = phraseRepository.findById(phraseId).orElseThrow(
         () -> new CustomException(NOT_EXIST_PHRASE)
     );
 
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     boolean authenticatedUser = isAuthenticatedUser(authentication);
     String nickname = "GUEST";
     Integer rank = null;

--- a/src/main/java/dasi/typing/domain/member/MemberRepository.java
+++ b/src/main/java/dasi/typing/domain/member/MemberRepository.java
@@ -1,5 +1,6 @@
 package dasi.typing.domain.member;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   boolean existsByKakaoId(String kakaoId);
 
   boolean existsByNickname(String nickname);
+
+  Optional<Member> findByKakaoId(String kakaoId);
 
 }

--- a/src/main/java/dasi/typing/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/dasi/typing/jwt/JwtAuthenticationFilter.java
@@ -23,15 +23,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private static final String TOKEN_HEADER = "Authorization";
   private static final String TOKEN_PREFIX = "Bearer ";
+  private static final String REISSUE_URI = "/api/v1/members/reissue";
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
 
     String token = resolveToken(request);
+    String requestURI = request.getRequestURI();
 
-    if (StringUtils.isNotEmpty(token) && jwtTokenProvider.validateToken(token)) {
-
+    if (StringUtils.isNotEmpty(token) && (isReissueRequest(requestURI) || jwtTokenProvider.validateAccessToken(token))) {
       String kakaoId = jwtTokenProvider.getKakaoId(token);
       List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("USER");
 
@@ -51,5 +52,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       return bearerToken.substring(TOKEN_PREFIX.length());
     }
     return null;
+  }
+
+  private boolean isReissueRequest(String requestURI) {
+    return requestURI.equals(REISSUE_URI);
   }
 }

--- a/src/test/java/dasi/typing/domain/refreshToken/RefreshTokenRepositoryTest.java
+++ b/src/test/java/dasi/typing/domain/refreshToken/RefreshTokenRepositoryTest.java
@@ -1,0 +1,43 @@
+package dasi.typing.domain.refreshToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dasi.typing.exception.Code;
+import dasi.typing.exception.CustomException;
+import dasi.typing.jwt.JwtToken;
+import dasi.typing.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class RefreshTokenRepositoryTest {
+
+  @Autowired
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Autowired
+  private RefreshTokenRepository refreshTokenRepository;
+
+  @Test
+  @DisplayName("kakaoId로 Redis에 RefreshToken을 저장한 후, 해당 키로 정상 조회되어야 한다.")
+  void redisTokenSaveTest() {
+    // given
+    String kakaoId = "1234567890";
+    JwtToken jwtToken = jwtTokenProvider.generateToken(kakaoId);
+    String token = jwtToken.getRefreshToken();
+
+    // when
+    RefreshToken savedRefreshToken = refreshTokenRepository.save(RefreshToken.builder()
+        .kakaoId(kakaoId)
+        .token(token).build());
+
+    RefreshToken refreshToken = refreshTokenRepository.findByKakaoId(kakaoId).orElseThrow(
+        () -> new CustomException(Code.EXPIRED_REFRESH_TOKEN)
+    );
+
+    // then
+    assertThat(savedRefreshToken.getToken()).isEqualTo(refreshToken.getToken());
+  }
+}

--- a/src/test/java/dasi/typing/domain/refreshToken/RefreshTokenTest.java
+++ b/src/test/java/dasi/typing/domain/refreshToken/RefreshTokenTest.java
@@ -1,0 +1,47 @@
+package dasi.typing.domain.refreshToken;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dasi.typing.exception.Code;
+import dasi.typing.exception.CustomException;
+import dasi.typing.jwt.JwtToken;
+import dasi.typing.jwt.JwtTokenProvider;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@SpringBootTest
+class RefreshTokenTest {
+
+  @Autowired
+  private RedisTemplate<String, String> redisTemplate;
+
+  @Autowired
+  private JwtTokenProvider jwtTokenProvider;
+
+  @Test
+  @DisplayName("RefreshToken TTL 시간이 만료되면 조회 시 예외가 발생해야 한다.")
+  void redisRefreshTokenTTLExpirationTest() throws Exception {
+    // given
+    String kakaoId = "1234567890";
+    JwtToken jwtToken = jwtTokenProvider.generateToken(kakaoId);
+    String refreshToken = jwtToken.getRefreshToken();
+
+    // when
+    redisTemplate.opsForValue().set(kakaoId, refreshToken, Duration.ofSeconds(1));
+    Thread.sleep(2000);
+
+    // then
+    assertThatThrownBy(() -> {
+      String token = redisTemplate.opsForValue().get(kakaoId);
+      if (token == null) {
+        throw new CustomException(Code.EXPIRED_REFRESH_TOKEN);
+      }
+    }).isInstanceOf(CustomException.class)
+        .hasMessageContaining(Code.EXPIRED_REFRESH_TOKEN.getMessage());
+  }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#20 

## 📝 작업 내용
- refreshToken 활용한 회원 AccessToken 재발급 로직을 구현했습니다.
  - JwtAuthenticationFilter에서 만료된 AccessToken을 가지는 회원의 reissue 엔드포인트의 접근을 허용하도록 구현했습니다.
  - USER 자격만 접근 가능한 Controller에서 Authentication 정보를 reissue 서비스로 넘깁니다.
  - refreshToken이 유효한 경우, 회원의 kakaoId를 활용하여  AccessToken과 refreshToken을 재발급합니다.
  - refreshToken이 유요하지 않은 경우, 예외를 반환하며 프론트엔드 단에서 이를 받아 재로그인을 유도합니다.
- 원활한 로직 구현 및 테스트 진행을 위해서 이미 구현된 코드의 일부를 수정했습니다.
- refreshToken 유효성을 활용한 예외 반환 및 토큰 재발급 과정의 테스트를 진행했습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

