### PR TITLE
:white_check_mark: Test: Controller 단위 테스트 보완 및 구현

### DIFF
--- a/src/main/java/dasi/typing/api/controller/member/request/MemberCreateRequest.java
+++ b/src/main/java/dasi/typing/api/controller/member/request/MemberCreateRequest.java
@@ -3,9 +3,11 @@ package dasi.typing.api.controller.member.request;
 import dasi.typing.api.service.member.request.MemberCreateServiceRequest;
 import dasi.typing.domain.consent.ConsentType;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class MemberCreateRequest {
 
   private String nickname;

--- a/src/main/java/dasi/typing/api/controller/typing/request/TypingCreateRequest.java
+++ b/src/main/java/dasi/typing/api/controller/typing/request/TypingCreateRequest.java
@@ -2,8 +2,13 @@ package dasi.typing.api.controller.typing.request;
 
 
 import dasi.typing.api.service.typing.request.TypingCreateServiceRequest;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TypingCreateRequest {
 
   private Long phraseId;

--- a/src/main/java/dasi/typing/api/service/phrase/PhraseService.java
+++ b/src/main/java/dasi/typing/api/service/phrase/PhraseService.java
@@ -5,9 +5,11 @@ import dasi.typing.domain.phrase.PhraseRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PhraseService {
 
   private final PhraseRepository phraseRepository;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,9 +122,6 @@ spring:
               - account_email       # 카카오계정(이메일)
               - openid              # OIDC
 
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-
 front:
   server: ${FRONT_SERVER}
 

--- a/src/test/java/dasi/typing/ControllerTestSupport.java
+++ b/src/test/java/dasi/typing/ControllerTestSupport.java
@@ -1,0 +1,89 @@
+package dasi.typing;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasi.typing.api.controller.member.MemberController;
+import dasi.typing.api.controller.phrase.PhraseController;
+import dasi.typing.api.controller.ranking.RankingController;
+import dasi.typing.api.controller.typing.TypingController;
+import dasi.typing.api.service.member.MemberService;
+import dasi.typing.api.service.member.NicknameService;
+import dasi.typing.api.service.phrase.LuckyMessageService;
+import dasi.typing.api.service.phrase.PhraseService;
+import dasi.typing.api.service.ranking.RankingService;
+import dasi.typing.api.service.typing.TypingService;
+import dasi.typing.jwt.GuestPrincipal;
+import dasi.typing.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = {
+    MemberController.class,
+    PhraseController.class,
+    RankingController.class,
+    TypingController.class
+})
+public abstract class ControllerTestSupport {
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @MockitoBean
+  protected MemberService memberService;
+
+  @MockitoBean
+  protected TypingService typingService;
+
+  @MockitoBean
+  protected PhraseService phraseService;
+
+  @MockitoBean
+  protected RankingService rankingService;
+
+  @MockitoBean
+  protected NicknameService nicknameService;
+
+  @MockitoBean
+  protected LuckyMessageService luckyMessageService;
+
+  @MockitoBean
+  protected JwtTokenProvider jwtTokenProvider;
+
+  protected RequestPostProcessor guestAuth(String tempToken) {
+    GuestPrincipal guest = new GuestPrincipal(tempToken);
+    return authentication(new TestingAuthenticationToken(guest, null, "GUEST"));
+  }
+
+  protected RequestPostProcessor userAuth(String kakaoId) {
+    return authentication(new TestingAuthenticationToken(kakaoId, null, "USER"));
+  }
+
+  @BeforeEach
+  protected void setUp(WebApplicationContext webApplicationContext) {
+    this.mockMvc = MockMvcBuilders
+        .webAppContextSetup(webApplicationContext)
+        .apply(springSecurity())
+        .defaultRequest(post("/**").with(csrf()))
+        .defaultRequest(patch("/**").with(csrf()))
+        .defaultRequest(delete("/**").with(csrf()))
+        .build();
+  }
+}

--- a/src/test/java/dasi/typing/api/controller/member/MemberControllerTest.java
+++ b/src/test/java/dasi/typing/api/controller/member/MemberControllerTest.java
@@ -1,0 +1,321 @@
+package dasi.typing.api.controller.member;
+
+import static dasi.typing.exception.Code.ALREADY_EXIST_MEMBER;
+import static dasi.typing.exception.Code.ALREADY_EXIST_NICKNAME;
+import static dasi.typing.exception.Code.EXPIRED_REFRESH_TOKEN;
+import static dasi.typing.exception.Code.INVALID_ACCESS_TOKEN;
+import static dasi.typing.exception.Code.INVALID_CHARACTER_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_CV_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_LENGTH_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_TEMP_TOKEN;
+import static dasi.typing.exception.Code.KAKAO_ACCOUNT_NOT_REGISTERED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import dasi.typing.ControllerTestSupport;
+import dasi.typing.api.controller.member.request.MemberCreateRequest;
+import dasi.typing.api.controller.member.response.NicknameResponse;
+import dasi.typing.api.service.member.request.MemberCreateServiceRequest;
+import dasi.typing.api.service.member.request.MemberNicknameServiceRequest;
+import dasi.typing.domain.consent.ConsentType;
+import dasi.typing.exception.ApiResponse;
+import dasi.typing.exception.Code;
+import dasi.typing.exception.CustomException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+class MemberControllerTest extends ControllerTestSupport {
+
+  private final String BEARER_PREFIX = "Bearer ";
+  private final String REDIS_KEY_PREFIX = "auth:temp-token:";
+
+  private final String KAKAO_ID = "kakaoId";
+  private final String NICKNAME = "nickname";
+  private final String TEMP_TOKEN = "tempToken";
+  private final String ACCESS_TOKEN = "accessToken";
+  private final String RANDOM_NICKNAME = "RandomNickname";
+
+  @Test
+  @DisplayName("회원은 성공적으로 로그인하여 JWT 토큰을 발급받고, 헤더에 담아 정상적으로 응답을 반환한다.")
+  void signInSuccessTest() throws Exception {
+
+    // given
+    given(memberService.signIn(any(String.class)))
+        .willReturn(ACCESS_TOKEN);
+
+    // when & then
+    String expectedJson = createExpectedSuccessJson(true);
+
+    mockMvc.perform(
+            get("/api/v1/members")
+                .header(HttpHeaders.AUTHORIZATION, REDIS_KEY_PREFIX + TEMP_TOKEN)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(header().string(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + ACCESS_TOKEN))
+        .andExpect(content().json(expectedJson));
+
+    verify(memberService).signIn(TEMP_TOKEN);
+  }
+
+  @Test
+  @DisplayName("회원이 아닌 유저가 로그인 했을 때, KAKAO_ACCOUNT_NOT_REGISTERED 예외를 반환한다.")
+  void signInFailureTest() throws Exception {
+
+    // given
+    given(memberService.signIn(any(String.class)))
+        .willThrow(new CustomException(KAKAO_ACCOUNT_NOT_REGISTERED));
+
+    // when & then
+    String expectedJson = createExpectedErrorJson(KAKAO_ACCOUNT_NOT_REGISTERED);
+
+    mockMvc.perform(
+            get("/api/v1/members")
+                .header(HttpHeaders.AUTHORIZATION, REDIS_KEY_PREFIX)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+
+    verify(memberService).signIn(TEMP_TOKEN);
+  }
+
+  @Test
+  @DisplayName("회원이 아닌 유저가 회원가입에 성공하면 JWT 토큰을 발급받고, 헤더에 담아 정상적으로 응답을 반환한다.")
+  void signUpSuccessTest() throws Exception {
+
+    // given
+    given(memberService.signUp(any(String.class), any(MemberCreateServiceRequest.class)))
+        .willReturn(ACCESS_TOKEN);
+
+    MemberCreateRequest request = new MemberCreateRequest(NICKNAME,
+        List.of(ConsentType.TERMS_OF_SERVICE, ConsentType.PRIVACY_POLICY));
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedSuccessJson(true);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(header().string(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + ACCESS_TOKEN))
+        .andExpect(content().json(expectedJson));
+  }
+
+  private static Stream<Arguments> singUpScenarios() {
+    return Stream.of(
+        Arguments.of(ALREADY_EXIST_MEMBER),
+        Arguments.of(INVALID_TEMP_TOKEN)
+    );
+  }
+
+
+  @DisplayName("회원이 아닌 유저가 회원가입에 실패하면 상황에 맞는 예외를 반환한다.")
+  @ParameterizedTest(name = "[{index}] -> {0}")
+  @MethodSource("singUpScenarios")
+  void signUpFailureTest(Code code) throws Exception {
+
+    // given
+    given(memberService.signUp(any(String.class), any(MemberCreateServiceRequest.class)))
+        .willThrow(new CustomException(code));
+
+    MemberCreateRequest request = new MemberCreateRequest(NICKNAME,
+        List.of(ConsentType.TERMS_OF_SERVICE, ConsentType.PRIVACY_POLICY));
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedErrorJson(code);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+  }
+
+  @Test
+  @DisplayName("모든 닉네임 형식에 맞게 작성한 경우 정상적으로 응답을 반환한다.")
+  void validateNicknameSuccessTest() throws Exception {
+
+    // given
+    willDoNothing()
+        .given(memberService)
+        .validateNickname(any(MemberNicknameServiceRequest.class));
+
+    MemberNicknameServiceRequest request = MemberNicknameServiceRequest.builder()
+        .nickname("nickname").build();
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedSuccessJson(true);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/nickname/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+
+    verify(memberService).validateNickname(any(MemberNicknameServiceRequest.class));
+  }
+
+  private static Stream<Arguments> nicknameScenarios() {
+    return Stream.of(
+        Arguments.of("abcdefghijklmnop", INVALID_LENGTH_NICKNAME),
+        Arguments.of("abcdeㄹㅇ", INVALID_CV_NICKNAME),
+        Arguments.of("abcde*&^", INVALID_CHARACTER_NICKNAME),
+        Arguments.of("abcde", ALREADY_EXIST_NICKNAME)
+    );
+  }
+
+  @DisplayName("옳지 않은 닉네임은 상황에 맞는 예외를 반환한다.")
+  @ParameterizedTest(name = "[{index}] -> {1} 예외 상황 검증")
+  @MethodSource("nicknameScenarios")
+  void validateNicknameFailureTest(String nickname, Code code) throws Exception {
+
+    // given
+    willThrow(new CustomException(code))
+        .given(memberService)
+        .validateNickname(any(MemberNicknameServiceRequest.class));
+
+    MemberNicknameServiceRequest request = MemberNicknameServiceRequest.builder()
+        .nickname(nickname).build();
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedErrorJson(code);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/nickname/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+
+    verify(memberService).validateNickname(any(MemberNicknameServiceRequest.class));
+  }
+
+  @Test
+  @DisplayName("랜덤 닉네임을 생성하여 정상적으로 응답을 반환한다.")
+  void generateRandomNicknameTest() throws Exception {
+
+    // given
+    given(nicknameService.generate()).willReturn(RANDOM_NICKNAME);
+
+    // when
+    String expectedJson = createExpectedSuccessJson(
+        NicknameResponse.builder().nickname(RANDOM_NICKNAME).build());
+
+    // then
+    mockMvc.perform(
+            get("/api/v1/members/nickname/random")
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+
+    verify(nicknameService).generate();
+  }
+
+  @Test
+  @DisplayName("회원 ACCESS 토큰이 만료되면 REFRESH 토큰을 통해 재발급받고, 헤더에 담아 정상적으로 응답을 반환한다.")
+  void reissueSuccessTest() throws Exception {
+    // given
+    given(memberService.reissue(any(String.class)))
+        .willReturn(ACCESS_TOKEN);
+
+    // when
+    String expectedJson = createExpectedSuccessJson(true);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/reissue")
+                .with(userAuth(KAKAO_ID))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(header().string(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + ACCESS_TOKEN))
+        .andExpect(content().json(expectedJson));
+
+    verify(memberService).reissue(any(String.class));
+  }
+
+  private static Stream<Arguments> reissueScenarios() {
+    return Stream.of(
+        Arguments.of(INVALID_ACCESS_TOKEN),
+        Arguments.of(EXPIRED_REFRESH_TOKEN)
+    );
+  }
+
+  @DisplayName("회원 ACCESS 토큰 재발급이 실패하면 상황에 맞는 예외를 반환한다.")
+  @ParameterizedTest(name = "[{index}] -> {0}")
+  @MethodSource("reissueScenarios")
+  void reissueFailureTest(Code code) throws Exception {
+    // given
+    given(memberService.reissue(any(String.class)))
+        .willThrow(new CustomException(code));
+
+    // when
+    String expectedJson = createExpectedErrorJson(code);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/reissue")
+                .with(userAuth(KAKAO_ID))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+
+    verify(memberService).reissue(any(String.class));
+  }
+
+  private <T> String createExpectedSuccessJson(T data) throws JsonProcessingException {
+    ApiResponse<T> response = ApiResponse.success(data);
+    return objectMapper.writeValueAsString(response);
+  }
+
+  private String createExpectedErrorJson(Code code) throws JsonProcessingException {
+    ApiResponse<Boolean> response = ApiResponse.error(code);
+    return objectMapper.writeValueAsString(response);
+  }
+}

--- a/src/test/java/dasi/typing/api/controller/phrase/PhraseControllerTest.java
+++ b/src/test/java/dasi/typing/api/controller/phrase/PhraseControllerTest.java
@@ -1,0 +1,60 @@
+package dasi.typing.api.controller.phrase;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dasi.typing.ControllerTestSupport;
+import dasi.typing.api.controller.phrase.response.PhraseResponse;
+import dasi.typing.domain.phrase.Lang;
+import dasi.typing.domain.phrase.LangType;
+import dasi.typing.domain.phrase.Phrase;
+import dasi.typing.exception.ApiResponse;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser
+class PhraseControllerTest extends ControllerTestSupport {
+
+  @Test
+  @DisplayName("문장들을 조회하여 정상적으로 응답을 반환한다.")
+  void sendPhraseToClientTest() throws Exception {
+
+    // given
+    List<PhraseResponse> responses = createPhraseResponse();
+    given(phraseService.getRandomPhrases())
+        .willReturn(responses);
+
+    // when
+    ApiResponse<Map<String, List<PhraseResponse>>> expected
+        = ApiResponse.success("phrases", responses);
+    String expectedJson = objectMapper.writeValueAsString(expected);
+
+    // then
+    mockMvc.perform(
+            get("/api/v1/phrases")
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+
+    verify(phraseService).getRandomPhrases();
+  }
+
+  private List<PhraseResponse> createPhraseResponse() {
+    return List.of(PhraseResponse.from(
+        Phrase.builder()
+            .sentence("문장")
+            .title("제목")
+            .author("저자")
+            .lang(Lang.KO)
+            .type(LangType.POEM).build()
+    ));
+  }
+}

--- a/src/test/java/dasi/typing/api/controller/ranking/RankingControllerTest.java
+++ b/src/test/java/dasi/typing/api/controller/ranking/RankingControllerTest.java
@@ -1,56 +1,83 @@
 package dasi.typing.api.controller.ranking;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import dasi.typing.ControllerTestSupport;
+import dasi.typing.api.controller.ranking.response.RankingResponse;
+import dasi.typing.exception.ApiResponse;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@ActiveProfiles("test")
-@Sql(scripts = "/ranking.sql")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-class RankingControllerTest {
-
-  @Autowired
-  private MockMvc mockMvc;
+@WithMockUser
+class RankingControllerTest extends ControllerTestSupport {
 
   @Test
-  @DisplayName("실시간 랭킹 데이터를 조회하여 응답을 정상적으로 반환한다.")
-  void sendRealTimeRankingToClient() throws Exception {
-    // when & then
+  @DisplayName("실시간 랭킹 데이터를 조회하여 정상적으로 응답을 반환한다.")
+  void sendRealTimeRankingToClientTest() throws Exception {
+
+    // given
+    List<RankingResponse> responses = createRankingResponse();
+    given(rankingService.getRealTimeRanking())
+        .willReturn(responses);
+
+    // when
+    ApiResponse<Map<String, List<RankingResponse>>> expected
+        = ApiResponse.success("rankings", responses);
+    String expectedJson = objectMapper.writeValueAsString(expected);
+
+    // then
     mockMvc.perform(
             get("/api/v1/rankings/realtime")
         )
         .andDo(print())
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.code").value("0"))
-        .andExpect(jsonPath("$.message").value("success"))
-        .andExpect(jsonPath("$.data").isMap());
+        .andExpect(content().json(expectedJson));
+
+    verify(rankingService).getRealTimeRanking();
   }
 
   @Test
-  @DisplayName("현재 날짜에 해당하는 연월 랭킹 데이터를 조회하여 응답을 정상적으로 반환한다.")
-  void sendMonthlyRankingToClient() throws Exception {
-    // when & then
+  @DisplayName("현재 날짜에 해당하는 연월 랭킹 데이터를 조회하여 정상적으로 응답을 반환한다.")
+  void sendMonthlyRankingToClientTest() throws Exception {
+
+    // given
+    List<RankingResponse> responses = createRankingResponse();
+    given(rankingService.getMonthlyRanking())
+        .willReturn(responses);
+
+    // when
+    ApiResponse<Map<String, List<RankingResponse>>> expected
+        = ApiResponse.success("rankings", responses);
+    String expectedJson = objectMapper.writeValueAsString(expected);
+    System.out.println(expectedJson);
+
+    // then
     mockMvc.perform(
             get("/api/v1/rankings/monthly")
         )
         .andDo(print())
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.code").value("0"))
-        .andExpect(jsonPath("$.message").value("success"))
-        .andExpect(jsonPath("$.data").isMap());
+        .andExpect(content().json(expectedJson));
+
+    verify(rankingService).getMonthlyRanking();
   }
 
+  private static List<RankingResponse> createRankingResponse() {
+    return List.of(RankingResponse.builder()
+        .memberId(1L)
+        .nickname("dragon")
+        .score(180)
+        .createdDate(Timestamp.valueOf(LocalDateTime.now()))
+        .ranking(1L).build());
+  }
 }

--- a/src/test/java/dasi/typing/api/controller/typing/TypingControllerTest.java
+++ b/src/test/java/dasi/typing/api/controller/typing/TypingControllerTest.java
@@ -1,0 +1,92 @@
+package dasi.typing.api.controller.typing;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dasi.typing.ControllerTestSupport;
+import dasi.typing.api.controller.typing.request.TypingCreateRequest;
+import dasi.typing.api.service.typing.request.TypingCreateServiceRequest;
+import dasi.typing.api.service.typing.response.TypingResponse;
+import dasi.typing.domain.member.Role;
+import dasi.typing.exception.ApiResponse;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser
+class TypingControllerTest extends ControllerTestSupport {
+
+  private static Stream<Arguments> userScenarios() {
+    return Stream.of(
+        Arguments.of("anonymous", "GUEST", Role.GUEST),
+        Arguments.of("user", "USER", Role.USER)
+    );
+  }
+
+  @DisplayName("회원 유형에 따라 타자 수행 결과 정보를 전달하고, 행운의 메시지와 랭킹을 정상적으로 응답한다.")
+  @ParameterizedTest(name = "[{index}] username={0}, userRole={1} → expectedRole={2}")
+  @MethodSource("userScenarios")
+  void sendVariousUserTypingResultToClient(String username, String userRole, Role expectedRole)
+      throws Exception {
+
+    // given
+    TypingCreateRequest request = createTypingCreateRequest();
+    TypingResponse typingResponse = createTypingResponse(username, expectedRole);
+
+    given(
+        typingService.saveTyping(any(Authentication.class), any(TypingCreateServiceRequest.class)))
+        .willReturn(typingResponse);
+
+    given(luckyMessageService.generate()).willReturn("Lucky Message");
+
+    // when
+    ApiResponse<Map<String, TypingResponse>> response
+        = ApiResponse.success("typing", typingResponse);
+
+    String expectedJson = objectMapper.writeValueAsString(response);
+    String requestJson = objectMapper.writeValueAsString(request);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/typings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(user(username).roles(userRole))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson));
+
+    verify(typingService)
+        .saveTyping(any(Authentication.class), any(TypingCreateServiceRequest.class));
+  }
+
+  private static TypingCreateRequest createTypingCreateRequest() {
+    return TypingCreateRequest.builder()
+        .phraseId(1L)
+        .cpm(100)
+        .acc(100)
+        .wpm(100)
+        .maxCpm(150).build();
+  }
+
+  private static TypingResponse createTypingResponse(String username, Role expectedRole) {
+    return TypingResponse.builder()
+        .role(expectedRole)
+        .nickname(username)
+        .rank(1L)
+        .luckyMessage("Lucky Message").build();
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#36 

## 📝 작업 내용

- 모든 Controller에 대한 단위 테스트를 진행했습니다.
- 기존에 설정한 SNAKE_CASE 네이밍 전략을 테스트에 한해서는 Jackson 메시지 컨버터가 CAMEL_CASE로 변환할 수 있도록 설정 코드를 삭제했습니다.
- Security 인증 객체를 WithMockUser 어노테이션을 통해서 가짜 객체를 만들어 원활한 테스트가 되도록 구현했습니다.
- 분기가 이루어지는 테스트에 대해서는 ParameterizedTest 기법을 활용하여 동적으로 테스트를 진행했습니다. 
- Controller 테스트에 존재하는 중복 코드를 줄이기 위해서 ControllerTestSupport 추상 클래스를 구현했습니다. 다음과 같은 이점을 가집니다.
  - 의존성 주입과 MockitoBean 객체들을 상속받도록 하여 코드의 복잡도를 낮춥니다.
  - 동일한 환경 설정을 구성하여 한번 로드한 ApplicationContext를 재사용함으로써 테스트 속도를 향상시켰습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

