### PR TITLE
:sparkles: Feat: API 문서를 작성하기 위한 Spring REST Docs 기술 적용 및 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 .gitattributes
 /src/main/generated/
 /src/main/generated_tests/
+/src/main/resources/static/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -65,18 +66,61 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Spring REST Docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
 }
 
-tasks.named('test') {
-    outputs.dir snippetsDir
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
     useJUnitPlatform()
+    outputs.dir snippetsDir
 }
 
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+tasks.register('copyApiDocument', Copy) {
+    dependsOn asciidoctor
+    doFirst {
+        delete file("src/main/resources/static/docs")
+    }
+    from asciidoctor.outputDir
+    into file("src/main/resources/static/docs")
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+
+    sources {
+        include("**/index.adoc", '**/*.adoc')
+    }
+    baseDirFollowsSourceFile()
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
+    from("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
+}
+
+
+build {
+    dependsOn copyApiDocument
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/src/docs/asciidoc/api/index.adoc
+++ b/src/docs/asciidoc/api/index.adoc
@@ -1,0 +1,39 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= 타자모어 REST API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:docinfo: shared-head
+:docs-url: ../../docs/api
+
+[[Overview]]
+include::overview.adoc[]
+
+[[API-List]]
+== APIs
+
+=== Member API
+
+* link:{docs-url}/member/memberSignIn.html[카카오 로그인 API,window=_blank]
+* link:{docs-url}/member/memberSignUp.html[회원가입 API,window=_blank]
+* link:{docs-url}/member/memberRandomNickname.html[랜덤 닉네임 생성 API,window=_blank]
+* link:{docs-url}/member/memberValidateNickname.html[닉네임 검증 API,window=_blank]
+* link:{docs-url}/member/memberReissue.html[회원 토큰 재발급 API,window=_blank]
+
+=== Phrase API
+
+* link:{docs-url}/phrase/phraseRetrieve.html[타자 문장 조회 API,window=_blank]
+
+=== Ranking API
+
+* link:{docs-url}/ranking/rankingRealtime.html[실시간 전체 랭킹 조회 API,window=_blank]
+* link:{docs-url}/ranking/rankingMonthly.html[월별 전체 랭킹 조회 API,window=_blank]
+
+=== Typing API
+
+* link:{docs-url}/typing/typingResultSave.html[타이핑 결과 정보 저장 API,window=_blank]

--- a/src/docs/asciidoc/api/member/memberRandomNickname.adoc
+++ b/src/docs/asciidoc/api/member/memberRandomNickname.adoc
@@ -1,0 +1,23 @@
+[[random-nickname]]
+== 랜덤 닉네임 생성 API
+
+=== Request
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/generateRandomNicknameTest/http-request.adoc[]
+'''
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/generateRandomNicknameTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/MemberControllerDocsTest/generateRandomNicknameTest/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberControllerDocsTest/generateRandomNicknameTest/http-response.adoc[]

--- a/src/docs/asciidoc/api/member/memberReissue.adoc
+++ b/src/docs/asciidoc/api/member/memberReissue.adoc
@@ -1,0 +1,63 @@
+[[reissue]]
+= 회원 재발급 API
+
+[[reissue-success]]
+== 성공하는 경우
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/MemberControllerDocsTest/reissueSuccessTest/request-headers.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/reissueSuccessTest/http-request.adoc[]
+'''
+
+=== Response
+
+==== Response Header
+
+include::{snippets}/MemberControllerDocsTest/reissueSuccessTest/response-headers.adoc[]
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/reissueSuccessTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/MemberControllerDocsTest/reissueSuccessTest/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberControllerDocsTest/reissueSuccessTest/http-response.adoc[]
+
+[[reissue-failure]]
+== 실패하는 경우
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/MemberControllerDocsTest/reissueInvalidAccessTokenFailureTest/request-headers.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/reissueFailureTest/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/reissueInvalidAccessTokenFailureTest/response-body.adoc[]
+include::{snippets}/MemberControllerDocsTest/reissueFailureTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/MemberControllerDocsTest/reissueInvalidAccessTokenFailureTest/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberControllerDocsTest/reissueInvalidAccessTokenFailureTest/http-response.adoc[]
+include::{snippets}/MemberControllerDocsTest/reissueFailureTest/http-response.adoc[]

--- a/src/docs/asciidoc/api/member/memberSignIn.adoc
+++ b/src/docs/asciidoc/api/member/memberSignIn.adoc
@@ -1,0 +1,60 @@
+[[sign-in]]
+= 유저 로그인
+
+[[success-sign-in]]
+== 성공하는 경우
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/request-headers.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/http-request.adoc[]
+
+=== Response
+
+==== Response Header
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/response-headers.adoc[]
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/http-response.adoc[]
+
+[[failure-sign-in]]
+== 실패하는 경우
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/MemberControllerDocsTest/signInFailureTest/request-headers.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/signInFailureTest/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/signInFailureTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/MemberControllerDocsTest/signInFailureTest/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberControllerDocsTest/signInFailureTest/http-response.adoc[]

--- a/src/docs/asciidoc/api/member/memberSignUp.adoc
+++ b/src/docs/asciidoc/api/member/memberSignUp.adoc
@@ -1,0 +1,72 @@
+[[sign-up]]
+= 유저 회원가입
+
+[[success-sign-up]]
+== 성공하는 경우
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/request-headers.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/http-request.adoc[]
+
+=== Response
+
+==== Response Header
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/response-headers.adoc[]
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberControllerDocsTest/signInSuccessTest/http-response.adoc[]
+
+[[failure-sign-up]]
+== 실패하는 경우
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/MemberControllerDocsTest/signUpAlreadyExistMemberFailureTest/request-headers.adoc[]
+
+==== Request Body
+
+include::{snippets}/MemberControllerDocsTest/signUpAlreadyExistMemberFailureTest/request-body.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/signUpAlreadyExistMemberFailureTest/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/signUpAlreadyExistMemberFailureTest/response-body.adoc[]
+include::{snippets}/MemberControllerDocsTest/signUpInvalidTempTokenFailureTest/response-body.adoc[]
+
+==== Response Fields
+
+===== -> 해당 식별값이 이미 존재하는 회원인 경우
+
+include::{snippets}/MemberControllerDocsTest/signUpAlreadyExistMemberFailureTest/response-fields.adoc[]
+
+===== -> 임시 토큰이 존재하지 않거나, 유효하지 않은 경우
+
+include::{snippets}/MemberControllerDocsTest/signUpInvalidTempTokenFailureTest/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberControllerDocsTest/signUpAlreadyExistMemberFailureTest/http-response.adoc[]
+include::{snippets}/MemberControllerDocsTest/signUpInvalidTempTokenFailureTest/http-response.adoc[]

--- a/src/docs/asciidoc/api/member/memberValidateNickname.adoc
+++ b/src/docs/asciidoc/api/member/memberValidateNickname.adoc
@@ -1,0 +1,73 @@
+[[validate-nickname]]
+= 닉네임 검증 API
+
+[[validate-nickname-success]]
+== 닉네임 검증 성공하는 경우
+
+=== Request
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameSuccessTest/http-request.adoc[]
+
+==== Request Fields
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameSuccessTest/request-fields.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameSuccessTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameSuccessTest/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameSuccessTest/http-response.adoc[]
+
+[[validate-nickname-failure]]
+== 닉네임 검증 실패하는 경우
+
+=== Request
+
+==== Request Body
+
+===== -> 2자 ~ 12자 길이 조건을 만족하지 못한 경우
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidLengthNicknameFailureTest/request-body.adoc[]
+
+===== -> 자음 또는 모음이 1개 이상 포함된 경우
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidCVNicknameFailureTest/request-body.adoc[]
+
+===== -> 특수문자 포함된 경우
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidCharacterNicknameFailureTest/request-body.adoc[]
+
+===== -> 해당 닉네임이 이미 존재하는 경우
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameAlreadyExistNicknameFailureTest/request-body.adoc[]
+
+==== Request Fields
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidLengthNicknameFailureTest/request-fields.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidLengthNicknameFailureTest/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidLengthNicknameFailureTest/response-body.adoc[]
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidCVNicknameFailureTest/response-body.adoc[]
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidCharacterNicknameFailureTest/response-body.adoc[]
+include::{snippets}/MemberControllerDocsTest/validateNicknameAlreadyExistNicknameFailureTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/MemberControllerDocsTest/validateNicknameInvalidLengthNicknameFailureTest/response-fields.adoc[]

--- a/src/docs/asciidoc/api/overview.adoc
+++ b/src/docs/asciidoc/api/overview.adoc
@@ -1,0 +1,116 @@
+[[overview]]
+== Overview
+
+[[overview-host]]
+=== Host
+
+|===
+| 환경 | Host
+
+| Beta
+| link:https://github.com/Bumnote[Github: Bumnote,window=_blank]
+
+| Production
+| link:https://github.com/Bumnote[Github: Bumnote,window=_blank]
+|===
+
+[[overview-http-status-codes]]
+=== HTTP status codes
+
+|===
+| 상태 코드 | 설명
+
+| `200 OK`
+| 성공
+
+| `400 Bad Request`
+| 잘못된 요청
+
+| `401 Unauthorized`
+| 비인증 상태
+
+| `403 Forbidden`
+| 권한 거부
+
+| `404 Not Found`
+| 존재하지 않는 요청 리소스
+
+| `500 Internal Server Error`
+| 서버 에러
+|===
+
+[[Custom-status-codes]]
+=== Custom status codes
+
+|===
+| 상태 코드 | 설명
+
+| `0`
+| success
+
+| Nickname
+|
+
+| `1000`
+| 띄어쓰기 없이 2자 ~ 12자까지 가능해요.
+
+| `1001`
+| 자음, 모음은 닉네임 설정 불가합니다.
+
+| `1002`
+| 한글, 영문, 숫자만 입력해주세요.
+
+| `1003`
+| 이미 사용중인 닉네임이에요.
+
+| Phrase
+|
+
+| `2000`
+| 해당 문장이 존재하지 않습니다.
+
+| Member & Kakao OAuth
+|
+
+| `3000`
+| 이미 존재하는 유저입니다.
+
+| `3001`
+| Kakao 사용자 정보를 가져오는데 실패했습니다.
+
+| `3002`
+| 카카오 계정이 등록되어 있지 않습니다. 회원가입이 필요합니다.
+
+| `3003`
+| 존재하지 않는 유저입니다.
+
+| Temp Token
+|
+
+| `4000`
+| 유효하지 않은 임시 토큰입니다.
+
+| JWT Token
+|
+
+| `5000`
+| 유효하지 않은 ACCESS_JWT 서명입니다.
+
+| `5001`
+| 만료된 ACCESS_JWT 토큰입니다.
+
+| `5002`
+| 유효하지 않은 REFRESH_JWT 서명입니다.
+
+| `5003`
+| 만료된 REFRESH_JWT 토큰입니다.
+
+| `5004`
+| 지원되지 않는 JWT 토큰 형식입니다.
+
+| `5005`
+| 토큰이 비어있거나 제공되지 않았습니다.
+|===
+
+[[overview-error-response]]
+=== HTTP Error Response

--- a/src/docs/asciidoc/api/phrase/phraseRetrieve.adoc
+++ b/src/docs/asciidoc/api/phrase/phraseRetrieve.adoc
@@ -1,0 +1,25 @@
+[[phrase-retrieve]]
+= 타이핑 문장 조회 API
+
+[[phrase-retrieve-success]]
+== 문장 조회 성공하는 경우
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/PhraseControllerDocsTest/sendPhraseToClientTest/request-headers.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/PhraseControllerDocsTest/sendPhraseToClientTest/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/PhraseControllerDocsTest/sendPhraseToClientTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/PhraseControllerDocsTest/sendPhraseToClientTest/response-fields.adoc[]

--- a/src/docs/asciidoc/api/ranking/rankingMonthly.adoc
+++ b/src/docs/asciidoc/api/ranking/rankingMonthly.adoc
@@ -1,0 +1,25 @@
+[[ranking-Retrieve]]
+= 랭킹 조회 API
+
+[[ranking-monthly]]
+== 월별 랭킹 조회
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/RankingControllerDocsTest/sendMonthlyRankingToClientTest/request-headers.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/RankingControllerDocsTest/sendMonthlyRankingToClientTest/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/RankingControllerDocsTest/sendMonthlyRankingToClientTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/RankingControllerDocsTest/sendMonthlyRankingToClientTest/response-fields.adoc[]

--- a/src/docs/asciidoc/api/ranking/rankingRealtime.adoc
+++ b/src/docs/asciidoc/api/ranking/rankingRealtime.adoc
@@ -1,0 +1,25 @@
+[[ranking-Retrieve]]
+= 랭킹 조회 API
+
+[[ranking-realtime]]
+== 실시간 랭킹 조회
+
+=== Request
+
+==== Request Header
+
+include::{snippets}/RankingControllerDocsTest/sendRealTimeRankingToClientTest/request-headers.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/RankingControllerDocsTest/sendRealTimeRankingToClientTest/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/RankingControllerDocsTest/sendRealTimeRankingToClientTest/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/RankingControllerDocsTest/sendRealTimeRankingToClientTest/response-fields.adoc[]

--- a/src/docs/asciidoc/api/typing/typingResultSave.adoc
+++ b/src/docs/asciidoc/api/typing/typingResultSave.adoc
@@ -1,0 +1,66 @@
+== Typing-API
+
+[[typing]]
+= 타이핑 결과 저장 
+
+[[GUEST]]
+== 비회원인 경우
+
+=== Request
+
+==== Request Body
+
+include::{snippets}/TypingControllerDocsTest/sendGuestTypingResultToClient/request-body.adoc[]
+
+==== Request Field
+
+include::{snippets}/TypingControllerDocsTesT/sendGuestTypingResultToClient/request-fields.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/TypingControllerDocsTest/sendGuestTypingResultToClient/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/TypingControllerDocsTest/sendGuestTypingResultToClient/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/TypingControllerDocsTest/sendGuestTypingResultToClient/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/TypingControllerDocsTest/sendGuestTypingResultToClient/http-response.adoc[]
+
+[[USER]]
+== 유저인 경우
+
+=== Request
+
+==== Request Body
+
+include::{snippets}/TypingControllerDocsTest/sendUserTypingResultToClient/request-body.adoc[]
+
+==== Request Field
+
+include::{snippets}/TypingControllerDocsTest/sendUserTypingResultToClient/request-fields.adoc[]
+
+==== HTTP Request
+
+include::{snippets}/TypingControllerDocsTest/sendUserTypingResultToClient/http-request.adoc[]
+
+=== Response
+
+==== Response Body
+
+include::{snippets}/TypingControllerDocsTest/sendUserTypingResultToClient/response-body.adoc[]
+
+==== Response Fields
+
+include::{snippets}/TypingControllerDocsTest/sendUserTypingResultToClient/response-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/TypingControllerDocsTest/sendUserTypingResultToClient/http-response.adoc[]

--- a/src/main/java/dasi/typing/config/WebConfig.java
+++ b/src/main/java/dasi/typing/config/WebConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @EnableWebMvc
@@ -21,5 +22,12 @@ public class WebConfig implements WebMvcConfigurer {
         .allowedHeaders("*")
         .exposedHeaders("Authorization")
         .allowCredentials(true);
+  }
+
+  @Override
+  public void addResourceHandlers(ResourceHandlerRegistry registry) {
+    registry
+        .addResourceHandler("/docs/**")
+        .addResourceLocations("classpath:/static/docs/");
   }
 }

--- a/src/test/java/dasi/typing/api/controller/docs/RestDocsSupport.java
+++ b/src/test/java/dasi/typing/api/controller/docs/RestDocsSupport.java
@@ -1,0 +1,105 @@
+package dasi.typing.api.controller.docs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasi.typing.api.controller.member.MemberController;
+import dasi.typing.api.controller.phrase.PhraseController;
+import dasi.typing.api.controller.ranking.RankingController;
+import dasi.typing.api.controller.typing.TypingController;
+import dasi.typing.api.service.member.MemberService;
+import dasi.typing.api.service.member.NicknameService;
+import dasi.typing.api.service.phrase.LuckyMessageService;
+import dasi.typing.api.service.phrase.PhraseService;
+import dasi.typing.api.service.ranking.RankingService;
+import dasi.typing.api.service.typing.TypingService;
+import dasi.typing.config.RestDocsConfig;
+import dasi.typing.config.TestSecurityConfig;
+import dasi.typing.jwt.GuestPrincipal;
+import dasi.typing.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.snippet.Attributes;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = {
+    MemberController.class,
+    PhraseController.class,
+    RankingController.class,
+    TypingController.class
+})
+@ExtendWith(RestDocumentationExtension.class)
+@Import({RestDocsConfig.class, TestSecurityConfig.class})
+public abstract class RestDocsSupport {
+
+  protected MockMvc mockMvc;
+
+  protected ObjectMapper objectMapper = new ObjectMapper();
+
+  @Autowired
+  protected RestDocumentationResultHandler restDocs;
+
+  @MockitoBean
+  protected MemberService memberService;
+
+  @MockitoBean
+  protected TypingService typingService;
+
+  @MockitoBean
+  protected PhraseService phraseService;
+
+  @MockitoBean
+  protected RankingService rankingService;
+
+  @MockitoBean
+  protected NicknameService nicknameService;
+
+  @MockitoBean
+  protected LuckyMessageService luckyMessageService;
+
+  @MockitoBean
+  protected JwtTokenProvider jwtTokenProvider;
+
+  @BeforeEach
+  void setUp(
+      final WebApplicationContext webApplicationContext,
+      final RestDocumentationContextProvider provider) {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+        .apply(documentationConfiguration(provider))
+        .apply(springSecurity())
+        .alwaysDo(print())
+        .alwaysDo(restDocs)
+        .build();
+  }
+
+  protected static Attributes.Attribute constraints(final String value) {
+    return new Attributes.Attribute("constraints", value);
+  }
+
+  protected RequestPostProcessor guestAuth(String tempToken) {
+    GuestPrincipal guest = new GuestPrincipal(tempToken);
+    return authentication(new TestingAuthenticationToken(guest, null, "GUEST"));
+  }
+
+  protected RequestPostProcessor userAuth(String kakaoId) {
+    return authentication(new TestingAuthenticationToken(kakaoId, null, "USER"));
+  }
+
+  protected abstract Object initController();
+}

--- a/src/test/java/dasi/typing/api/controller/docs/member/MemberControllerDocsTest.java
+++ b/src/test/java/dasi/typing/api/controller/docs/member/MemberControllerDocsTest.java
@@ -1,0 +1,666 @@
+package dasi.typing.api.controller.docs.member;
+
+import static dasi.typing.exception.Code.ALREADY_EXIST_MEMBER;
+import static dasi.typing.exception.Code.ALREADY_EXIST_NICKNAME;
+import static dasi.typing.exception.Code.EXPIRED_REFRESH_TOKEN;
+import static dasi.typing.exception.Code.INVALID_ACCESS_TOKEN;
+import static dasi.typing.exception.Code.INVALID_CHARACTER_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_CV_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_LENGTH_NICKNAME;
+import static dasi.typing.exception.Code.INVALID_TEMP_TOKEN;
+import static dasi.typing.exception.Code.KAKAO_ACCOUNT_NOT_REGISTERED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import dasi.typing.api.controller.docs.RestDocsSupport;
+import dasi.typing.api.controller.member.MemberController;
+import dasi.typing.api.controller.member.request.MemberCreateRequest;
+import dasi.typing.api.controller.member.response.NicknameResponse;
+import dasi.typing.api.service.member.request.MemberCreateServiceRequest;
+import dasi.typing.api.service.member.request.MemberNicknameServiceRequest;
+import dasi.typing.domain.consent.ConsentType;
+import dasi.typing.exception.ApiResponse;
+import dasi.typing.exception.Code;
+import dasi.typing.exception.CustomException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+class MemberControllerDocsTest extends RestDocsSupport {
+
+  private final String BEARER_PREFIX = "Bearer ";
+  private final String REDIS_KEY_PREFIX = "auth:temp-token:";
+
+  private final String KAKAO_ID = "1234567890";
+  private final String NICKNAME = "dragon";
+  private final String TEMP_TOKEN = "457e32c9-9780-41f7-923c-bfee04a44057";
+  private final String ACCESS_TOKEN = "Bearer eyJhbGciOi...";
+  private final String RANDOM_NICKNAME = "아름다운취준생";
+
+  @Override
+  protected Object initController() {
+    return new MemberController(memberService, nicknameService);
+  }
+
+  @Test
+  @DisplayName("회원은 성공적으로 로그인하여 JWT 토큰을 발급받고, 헤더에 담아 정상적으로 응답을 반환한다.")
+  void signInSuccessTest() throws Exception {
+
+    // given
+    given(memberService.signIn(any(String.class)))
+        .willReturn(ACCESS_TOKEN);
+
+    // when & then
+    String expectedJson = createExpectedSuccessJson(true);
+
+    mockMvc.perform(
+            get("/api/v1/members")
+                .header(HttpHeaders.AUTHORIZATION, REDIS_KEY_PREFIX + TEMP_TOKEN)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andExpect(status().isOk())
+        .andExpect(header().string(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + ACCESS_TOKEN))
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("임시 인증 토큰 -> `auth:temp-token:{tempToken}`")
+            ),
+
+            responseHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("회원 ACCESS TOKEN")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("회원이 아닌 유저가 로그인 했을 때, KAKAO_ACCOUNT_NOT_REGISTERED 예외를 반환한다.")
+  void signInFailureTest() throws Exception {
+
+    // given
+    given(memberService.signIn(any(String.class)))
+        .willThrow(new CustomException(KAKAO_ACCOUNT_NOT_REGISTERED));
+
+    // when & then
+    String expectedJson = createExpectedErrorJson(KAKAO_ACCOUNT_NOT_REGISTERED);
+
+    mockMvc.perform(
+            get("/api/v1/members")
+                .header(HttpHeaders.AUTHORIZATION, REDIS_KEY_PREFIX + TEMP_TOKEN)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("임시 인증 토큰 -> `auth:temp-token:{tempToken}`")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("회원이 아닌 유저가 이미 존재하는 회원의 식별값을 통해 회원가입을 시도하면 ALREADY_EXIST_MEMBER 예외를 반환한다.")
+  void signUpAlreadyExistMemberFailureTest() throws Exception {
+
+    // given
+    given(memberService.signUp(any(String.class), any(MemberCreateServiceRequest.class)))
+        .willThrow(new CustomException(ALREADY_EXIST_MEMBER));
+
+    MemberCreateRequest request = new MemberCreateRequest(NICKNAME,
+        List.of(ConsentType.TERMS_OF_SERVICE, ConsentType.PRIVACY_POLICY));
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedErrorJson(ALREADY_EXIST_MEMBER);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members")
+                .header(HttpHeaders.AUTHORIZATION, UUID.randomUUID().toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("카카오 로그인으로 발급된 임시 토큰 (3분 유효)")
+            ),
+
+            requestFields(
+                fieldWithPath("nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("검증 대상 닉네임"),
+                fieldWithPath("agreements")
+                    .type(JsonFieldType.ARRAY)
+                    .description("필수 동의 항목 리스트"),
+                fieldWithPath("agreements[]")
+                    .type(JsonFieldType.ARRAY)
+                    .description("동의 항목 (TERMS_OF_SERVICE, PRIVACY_POLICY)")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("임시 토큰이 없는 유저가 회원가입을 시도하면 INVALID_TEMP_TOKEN 예외를 반환한다.")
+  void signUpInvalidTempTokenFailureTest() throws Exception {
+
+    // given
+    given(memberService.signUp(any(String.class), any(MemberCreateServiceRequest.class)))
+        .willThrow(new CustomException(INVALID_TEMP_TOKEN));
+
+    MemberCreateRequest request = new MemberCreateRequest(NICKNAME,
+        List.of(ConsentType.TERMS_OF_SERVICE, ConsentType.PRIVACY_POLICY));
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedErrorJson(INVALID_TEMP_TOKEN);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members")
+                .header(HttpHeaders.AUTHORIZATION, UUID.randomUUID().toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("카카오 로그인으로 발급된 임시 토큰 (3분 유효)")
+            ),
+
+            requestFields(
+                fieldWithPath("nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("검증 대상 닉네임"),
+                fieldWithPath("agreements")
+                    .type(JsonFieldType.ARRAY)
+                    .description("필수 동의 항목 리스트"),
+                fieldWithPath("agreements[]")
+                    .type(JsonFieldType.ARRAY)
+                    .description("동의 항목 (TERMS_OF_SERVICE, PRIVACY_POLICY)")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("모든 닉네임 형식에 맞게 작성한 경우 정상적으로 응답을 반환한다.")
+  void validateNicknameSuccessTest() throws Exception {
+
+    // given
+    willDoNothing()
+        .given(memberService)
+        .validateNickname(any(MemberNicknameServiceRequest.class));
+
+    MemberNicknameServiceRequest request = MemberNicknameServiceRequest.builder()
+        .nickname(NICKNAME).build();
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedSuccessJson(true);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/nickname/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("검증 대상 닉네임")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("2자 ~ 12자의 닉네임 길이 조건을 만족하지 못하면 INVALID_LENGTH_NICKNAME 예외를 반환한다.")
+  void validateNicknameInvalidLengthNicknameFailureTest() throws Exception {
+
+    // given
+    willThrow(new CustomException(INVALID_LENGTH_NICKNAME))
+        .given(memberService)
+        .validateNickname(any(MemberNicknameServiceRequest.class));
+
+    MemberNicknameServiceRequest request = MemberNicknameServiceRequest.builder()
+        .nickname("abcdefghijklmnop").build();
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedErrorJson(INVALID_LENGTH_NICKNAME);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/nickname/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("검증 대상 닉네임")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("자음 또는 모음이 포함된 닉네임은 INVALID_CV_NICKNAME 예외를 반환한다.")
+  void validateNicknameInvalidCVNicknameFailureTest() throws Exception {
+
+    // given
+    willThrow(new CustomException(INVALID_CV_NICKNAME))
+        .given(memberService)
+        .validateNickname(any(MemberNicknameServiceRequest.class));
+
+    MemberNicknameServiceRequest request = MemberNicknameServiceRequest.builder()
+        .nickname("abcdeㄹㅇ").build();
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedErrorJson(INVALID_CV_NICKNAME);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/nickname/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("검증 대상 닉네임")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("특수 문자가 포함된 닉네임은 INVALID_CHARACTER_NICKNAME 예외를 반환한다.")
+  void validateNicknameInvalidCharacterNicknameFailureTest() throws Exception {
+
+    // given
+    willThrow(new CustomException(INVALID_CHARACTER_NICKNAME))
+        .given(memberService)
+        .validateNickname(any(MemberNicknameServiceRequest.class));
+
+    MemberNicknameServiceRequest request = MemberNicknameServiceRequest.builder()
+        .nickname("abcde*&^").build();
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedErrorJson(INVALID_CHARACTER_NICKNAME);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/nickname/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("검증 대상 닉네임")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("이미 사용 중인 닉네임은 ALREADY_EXIST_NICKNAME 예외를 반환한다.")
+  void validateNicknameAlreadyExistNicknameFailureTest() throws Exception {
+
+    // given
+    willThrow(new CustomException(ALREADY_EXIST_NICKNAME))
+        .given(memberService)
+        .validateNickname(any(MemberNicknameServiceRequest.class));
+
+    MemberNicknameServiceRequest request = MemberNicknameServiceRequest.builder()
+        .nickname("dragon").build();
+
+    // when
+    String requestJson = objectMapper.writeValueAsString(request);
+    String expectedJson = createExpectedErrorJson(ALREADY_EXIST_NICKNAME);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/nickname/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("검증 대상 닉네임")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("랜덤 닉네임을 생성하여 정상적으로 응답을 반환한다.")
+  void generateRandomNicknameTest() throws Exception {
+
+    // given
+    given(nicknameService.generate()).willReturn(RANDOM_NICKNAME);
+
+    // when
+    String expectedJson = createExpectedSuccessJson(
+        NicknameResponse.builder().nickname(RANDOM_NICKNAME).build());
+
+    // then
+    mockMvc.perform(
+            get("/api/v1/members/nickname/random")
+                .with(guestAuth(TEMP_TOKEN))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.OBJECT)
+                    .description("응답 컨텐츠"),
+                fieldWithPath("data.nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("생성된 랜덤 닉네임")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("회원 ACCESS 토큰이 만료되면 REFRESH 토큰을 통해 재발급받고, 헤더에 담아 정상적으로 응답을 반환한다.")
+  void reissueSuccessTest() throws Exception {
+
+    // given
+    given(memberService.reissue(any(String.class)))
+        .willReturn(ACCESS_TOKEN);
+
+    // when
+    String expectedJson = createExpectedSuccessJson(true);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/reissue")
+                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                .with(userAuth(KAKAO_ID))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(header().string(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + ACCESS_TOKEN))
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("회원 ACCESS TOKEN")
+            ),
+
+            responseHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("발급된 JWT ACCESS TOKEN")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("회원 ACCESS 토큰이 유효하지 않은 경우 INVALID_ACCESS_TOKEN 예외를 반환한다.")
+  void reissueInvalidAccessTokenFailureTest() throws Exception {
+    // given
+    given(memberService.reissue(any(String.class)))
+        .willThrow(new CustomException(INVALID_ACCESS_TOKEN));
+
+    // when
+    String expectedJson = createExpectedErrorJson(INVALID_ACCESS_TOKEN);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/reissue")
+                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+
+                .with(userAuth(KAKAO_ID))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("회원 Access Token")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("회원 ACCESS 토큰이 만료된 경우 EXPIRED_REFRESH_TOKEN 예외를 반환한다.")
+  void reissueFailureTest() throws Exception {
+    // given
+    given(memberService.reissue(any(String.class)))
+        .willThrow(new CustomException(EXPIRED_REFRESH_TOKEN));
+
+    // when
+    String expectedJson = createExpectedErrorJson(EXPIRED_REFRESH_TOKEN);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/members/reissue")
+                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                .with(userAuth(KAKAO_ID))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("회원 Access Token")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.BOOLEAN)
+                    .description("응답 컨텐츠")
+            )
+        ));
+  }
+
+  private <T> String createExpectedSuccessJson(T data) throws JsonProcessingException {
+    ApiResponse<T> response = ApiResponse.success(data);
+    return objectMapper.writeValueAsString(response);
+  }
+
+  private String createExpectedErrorJson(Code code) throws JsonProcessingException {
+    ApiResponse<Boolean> response = ApiResponse.error(code);
+    return objectMapper.writeValueAsString(response);
+  }
+}

--- a/src/test/java/dasi/typing/api/controller/docs/phrase/PhraseControllerDocsTest.java
+++ b/src/test/java/dasi/typing/api/controller/docs/phrase/PhraseControllerDocsTest.java
@@ -1,0 +1,120 @@
+package dasi.typing.api.controller.docs.phrase;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dasi.typing.api.controller.docs.RestDocsSupport;
+import dasi.typing.api.controller.phrase.PhraseController;
+import dasi.typing.api.controller.phrase.response.PhraseResponse;
+import dasi.typing.domain.phrase.Lang;
+import dasi.typing.domain.phrase.LangType;
+import dasi.typing.exception.ApiResponse;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+class PhraseControllerDocsTest extends RestDocsSupport {
+
+  @Override
+  protected Object initController() {
+    return new PhraseController(phraseService);
+  }
+
+  private final String ACCESS_TOKEN = "Bearer eyJhbGciOi...";
+
+  @Test
+  @DisplayName("문장들을 조회하여 정상적으로 응답을 반환한다.")
+  void sendPhraseToClientTest() throws Exception {
+
+    // given
+    List<PhraseResponse> responses = createPhraseResponse();
+    given(phraseService.getRandomPhrases())
+        .willReturn(responses);
+
+    // when
+    ApiResponse<Map<String, List<PhraseResponse>>> expected
+        = ApiResponse.success("phrases", responses);
+    String expectedJson = objectMapper.writeValueAsString(expected);
+
+    // then
+    mockMvc.perform(
+            get("/api/v1/phrases")
+                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("회원 ACCESS TOKEN")
+                    .optional()
+            ),
+
+            // 공통 응답 바디 필드
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.OBJECT)
+                    .description("응답 컨텐츠"),
+                fieldWithPath("data.phrases")
+                    .type(JsonFieldType.ARRAY)
+                    .description("문장 리스트"),
+                fieldWithPath("data.phrases[].id")
+                    .type(JsonFieldType.NUMBER)
+                    .description("문장 식별자"),
+                fieldWithPath("data.phrases[].sentence")
+                    .type(JsonFieldType.STRING)
+                    .description("문장 내용"),
+                fieldWithPath("data.phrases[].title")
+                    .type(JsonFieldType.STRING)
+                    .description("문장 제목"),
+                fieldWithPath("data.phrases[].author")
+                    .type(JsonFieldType.STRING)
+                    .description("작성자"),
+                fieldWithPath("data.phrases[].lang")
+                    .type(JsonFieldType.STRING)
+                    .description("언어 코드 (예: KO, EN)"),
+                fieldWithPath("data.phrases[].type")
+                    .type(JsonFieldType.STRING)
+                    .description("문장 타입 (예: QUOTE, POEM)")
+            )
+        ));
+  }
+
+  private List<PhraseResponse> createPhraseResponse() {
+
+    PhraseResponse response1 = PhraseResponse.builder()
+        .id(1L)
+        .sentence("오늘도 화이팅")
+        .title("빛나는 하루")
+        .author("dragon")
+        .lang(Lang.KO.toString())
+        .type(LangType.POEM.toString()).build();
+
+    PhraseResponse response2 = PhraseResponse.builder()
+        .id(2L)
+        .sentence("Keep going")
+        .title("Fighting")
+        .author("dragon")
+        .lang(Lang.EN.toString())
+        .type(LangType.QUOTE.toString()).build();
+
+    return List.of(response1, response2);
+  }
+}

--- a/src/test/java/dasi/typing/api/controller/docs/ranking/RankingControllerDocsTest.java
+++ b/src/test/java/dasi/typing/api/controller/docs/ranking/RankingControllerDocsTest.java
@@ -1,0 +1,172 @@
+package dasi.typing.api.controller.docs.ranking;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dasi.typing.api.controller.docs.RestDocsSupport;
+import dasi.typing.api.controller.ranking.RankingController;
+import dasi.typing.api.controller.ranking.response.RankingResponse;
+import dasi.typing.exception.ApiResponse;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+class RankingControllerDocsTest extends RestDocsSupport {
+
+  @Override
+  protected Object initController() {
+    return new RankingController(rankingService);
+  }
+
+  private final String ACCESS_TOKEN = "Bearer eyJhbGciOi...";
+
+  @Test
+  @DisplayName("실시간 랭킹 데이터를 조회하여 정상적으로 응답을 반환한다.")
+  void sendRealTimeRankingToClientTest() throws Exception {
+
+    // given
+    List<RankingResponse> responses = createRankingResponse();
+    given(rankingService.getRealTimeRanking())
+        .willReturn(responses);
+
+    // when
+    ApiResponse<Map<String, List<RankingResponse>>> expected
+        = ApiResponse.success("rankings", responses);
+    String expectedJson = objectMapper.writeValueAsString(expected);
+
+    // then
+    mockMvc.perform(
+            get("/api/v1/rankings/realtime")
+                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("회원 ACCESS TOKEN")
+                    .optional()
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.OBJECT)
+                    .description("응답 컨텐츠"),
+                fieldWithPath("data.rankings")
+                    .type(JsonFieldType.ARRAY)
+                    .description("랭킹 리스트"),
+                fieldWithPath("data.rankings[].memberId")
+                    .type(JsonFieldType.NUMBER)
+                    .description("회원 식별자"),
+                fieldWithPath("data.rankings[].nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("회원 닉네임"),
+                fieldWithPath("data.rankings[].score")
+                    .type(JsonFieldType.NUMBER)
+                    .description("회원 점수"),
+                fieldWithPath("data.rankings[].ranking")
+                    .type(JsonFieldType.NUMBER)
+                    .description("회원 순위")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("현재 날짜에 해당하는 연월 랭킹 데이터를 조회하여 정상적으로 응답을 반환한다.")
+  void sendMonthlyRankingToClientTest() throws Exception {
+
+    // given
+    List<RankingResponse> responses = createRankingResponse();
+    given(rankingService.getMonthlyRanking())
+        .willReturn(responses);
+
+    // when
+    ApiResponse<Map<String, List<RankingResponse>>> expected
+        = ApiResponse.success("rankings", responses);
+    String expectedJson = objectMapper.writeValueAsString(expected);
+    System.out.println(expectedJson);
+
+    // then
+    mockMvc.perform(
+            get("/api/v1/rankings/monthly")
+                .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION)
+                    .description("회원 ACCESS TOKEN")
+                    .optional()
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.OBJECT)
+                    .description("응답 컨텐츠"),
+                fieldWithPath("data.rankings")
+                    .type(JsonFieldType.ARRAY)
+                    .description("랭킹 리스트"),
+                fieldWithPath("data.rankings[].memberId")
+                    .type(JsonFieldType.NUMBER)
+                    .description("회원 식별자"),
+                fieldWithPath("data.rankings[].nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("회원 닉네임"),
+                fieldWithPath("data.rankings[].score")
+                    .type(JsonFieldType.NUMBER)
+                    .description("회원 점수"),
+                fieldWithPath("data.rankings[].ranking")
+                    .type(JsonFieldType.NUMBER)
+                    .description("회원 순위")
+            )
+        ));
+
+  }
+
+  private static List<RankingResponse> createRankingResponse() {
+
+    RankingResponse response1 = RankingResponse.builder()
+        .memberId(1L)
+        .nickname("dragon")
+        .score(180)
+        .createdDate(Timestamp.valueOf(LocalDateTime.now()))
+        .ranking(1L).build();
+
+    RankingResponse response2 = RankingResponse.builder()
+        .memberId(2L)
+        .nickname("tiger")
+        .score(170)
+        .createdDate(Timestamp.valueOf(LocalDateTime.now()))
+        .ranking(2L).build();
+
+    return List.of(response1, response2);
+  }
+}

--- a/src/test/java/dasi/typing/api/controller/docs/typing/TypingControllerDocsTest.java
+++ b/src/test/java/dasi/typing/api/controller/docs/typing/TypingControllerDocsTest.java
@@ -1,0 +1,201 @@
+package dasi.typing.api.controller.docs.typing;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dasi.typing.api.controller.docs.RestDocsSupport;
+import dasi.typing.api.controller.typing.TypingController;
+import dasi.typing.api.controller.typing.request.TypingCreateRequest;
+import dasi.typing.api.service.typing.request.TypingCreateServiceRequest;
+import dasi.typing.api.service.typing.response.TypingResponse;
+import dasi.typing.domain.member.Role;
+import dasi.typing.exception.ApiResponse;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.core.Authentication;
+
+class TypingControllerDocsTest extends RestDocsSupport {
+
+  @Override
+  protected Object initController() {
+    return new TypingController(typingService);
+  }
+
+  @Test
+  @DisplayName("비회원이라면 행운의 메시지만 정상적으로 응답한다.")
+  void sendGuestTypingResultToClient() throws Exception {
+
+    // given
+    TypingCreateRequest request = createTypingCreateRequest();
+    TypingResponse typingResponse = createTypingResponse("anonymous", Role.GUEST);
+
+    given(
+        typingService.saveTyping(any(Authentication.class), any(TypingCreateServiceRequest.class)))
+        .willReturn(typingResponse);
+
+    given(luckyMessageService.generate()).willReturn("Lucky Message");
+
+    // when
+    ApiResponse<Map<String, TypingResponse>> response
+        = ApiResponse.success("typing", typingResponse);
+
+    String expectedJson = objectMapper.writeValueAsString(response);
+    String requestJson = objectMapper.writeValueAsString(request);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/typings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(user("anonymous").roles("GUEST"))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("phraseId").type(JsonFieldType.NUMBER)
+                    .description("문구 식별자"),
+                fieldWithPath("cpm").type(JsonFieldType.NUMBER)
+                    .description("타자 속도 (characters per minute)"),
+                fieldWithPath("acc").type(JsonFieldType.NUMBER)
+                    .description("정확도 (%)"),
+                fieldWithPath("wpm").type(JsonFieldType.NUMBER)
+                    .description("타자 속도 (words per minute)"),
+                fieldWithPath("maxCpm").type(JsonFieldType.NUMBER)
+                    .description("최대 타자 속도 (cpm)")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드 (0=성공, 그 외=에러)"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("응답 메시지"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.OBJECT)
+                    .description("응답 데이터 객체"),
+                fieldWithPath("data.typing")
+                    .type(JsonFieldType.OBJECT)
+                    .description("타이핑 정보를 담고 있는 객체"),
+                fieldWithPath("data.typing.role").type(JsonFieldType.STRING)
+                    .description("사용자 역할 (예: GUEST, USER)"),
+                fieldWithPath("data.typing.nickname").type(JsonFieldType.STRING)
+                    .description("사용자 닉네임"),
+                fieldWithPath("data.typing.rank").type(JsonFieldType.NUMBER)
+                    .description("순위 (회원인 경우에만 값이 있으며, 비회원은 null)"),
+                fieldWithPath("data.typing.luckyMessage").type(JsonFieldType.STRING)
+                    .description("행운의 메시지")
+            )
+        ));
+  }
+
+  @Test
+  @DisplayName("회원이라면 행운의 메시지와 랭킹을 정상적으로 응답한다.")
+  void sendUserTypingResultToClient() throws Exception {
+
+    // given
+    TypingCreateRequest request = createTypingCreateRequest();
+    TypingResponse typingResponse = createTypingResponse("dragon", Role.USER);
+
+    given(
+        typingService.saveTyping(any(Authentication.class), any(TypingCreateServiceRequest.class)))
+        .willReturn(typingResponse);
+
+    given(luckyMessageService.generate()).willReturn("Lucky Message");
+
+    // when
+    ApiResponse<Map<String, TypingResponse>> response
+        = ApiResponse.success("typing", typingResponse);
+
+    String expectedJson = objectMapper.writeValueAsString(response);
+    String requestJson = objectMapper.writeValueAsString(request);
+
+    // then
+    mockMvc.perform(
+            post("/api/v1/typings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+                .with(user("dragon").roles("USER"))
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content().json(expectedJson))
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("phraseId")
+                    .type(JsonFieldType.NUMBER)
+                    .description("문장 식별자"),
+                fieldWithPath("cpm")
+                    .type(JsonFieldType.NUMBER)
+                    .description("타자 속도"),
+                fieldWithPath("acc")
+                    .type(JsonFieldType.NUMBER)
+                    .description("정확도"),
+                fieldWithPath("wpm")
+                    .type(JsonFieldType.NUMBER)
+                    .description("타자 속도"),
+                fieldWithPath("maxCpm")
+                    .type(JsonFieldType.NUMBER)
+                    .description("최대 타자 속도 (cpm)")
+            ),
+
+            responseFields(
+                fieldWithPath("code")
+                    .type(JsonFieldType.NUMBER)
+                    .description("응답 코드"),
+                fieldWithPath("message")
+                    .type(JsonFieldType.STRING)
+                    .description("성공 여부"),
+                fieldWithPath("data")
+                    .type(JsonFieldType.OBJECT)
+                    .description("응답 컨텐츠"),
+                fieldWithPath("data.typing")
+                    .type(JsonFieldType.OBJECT)
+                    .description("타자 정보를 담고 있는 객체"),
+                fieldWithPath("data.typing.role")
+                    .type(JsonFieldType.STRING)
+                    .description("사용자 역할 (예: GUEST, USER)"),
+                fieldWithPath("data.typing.nickname")
+                    .type(JsonFieldType.STRING)
+                    .description("사용자 닉네임"),
+                fieldWithPath("data.typing.rank")
+                    .type(JsonFieldType.NUMBER)
+                    .description("순위 (회원인 경우에만 값이 있으며, 비회원은 null)"),
+                fieldWithPath("data.typing.luckyMessage")
+                    .type(JsonFieldType.STRING)
+                    .description("행운의 메시지")
+            )
+        ));
+  }
+
+  private static TypingCreateRequest createTypingCreateRequest() {
+    return TypingCreateRequest.builder()
+        .phraseId(1L)
+        .cpm(100)
+        .acc(100)
+        .wpm(100)
+        .maxCpm(150).build();
+  }
+
+  private static TypingResponse createTypingResponse(String username, Role expectedRole) {
+    return TypingResponse.builder()
+        .role(expectedRole)
+        .nickname(username)
+        .rank(1L)
+        .luckyMessage("Lucky Message").build();
+  }
+
+}

--- a/src/test/java/dasi/typing/api/service/ranking/RankingServiceTest.java
+++ b/src/test/java/dasi/typing/api/service/ranking/RankingServiceTest.java
@@ -47,6 +47,7 @@ class RankingServiceTest {
     memberRepository.deleteAllInBatch();
   }
 
+  @Disabled
   @Test
   @DisplayName("충분한 데이터가 존재할 때, 점수를 기준으로 내림차순하여 상위 50명의 데이터를 반환할 수 있다.")
   void getRealTimeRanking() {

--- a/src/test/java/dasi/typing/config/RestDocsConfig.java
+++ b/src/test/java/dasi/typing/config/RestDocsConfig.java
@@ -1,0 +1,37 @@
+package dasi.typing.config;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+  @Bean
+  public RestDocumentationResultHandler restDocumentationResultHandler() {
+    return MockMvcRestDocumentation.document(
+        "{ClassName}/{methodName}",
+        preprocessRequest(
+            modifyHeaders()
+                .remove("Content-Length")
+                .remove("Host"),
+            prettyPrint()),
+        preprocessResponse(
+            modifyHeaders()
+                .remove("Content-Length")
+                .remove("X-Content-Type-Options")
+                .remove("X-XSS-Protection")
+                .remove("Cache-Control")
+                .remove("Pragma")
+                .remove("Expires")
+                .remove("X-Frame-Options"),
+            prettyPrint())
+    );
+  }
+}

--- a/src/test/java/dasi/typing/config/TestSecurityConfig.java
+++ b/src/test/java/dasi/typing/config/TestSecurityConfig.java
@@ -1,0 +1,26 @@
+package dasi.typing.config;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@ImportAutoConfiguration(SecurityAutoConfiguration.class)
+public class TestSecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(auth -> auth
+            .anyRequest().permitAll()
+        );
+
+    return http.build();
+  }
+
+}

--- a/src/test/java/dasi/typing/domain/typing/TypingRepositoryTest.java
+++ b/src/test/java/dasi/typing/domain/typing/TypingRepositoryTest.java
@@ -43,6 +43,7 @@ class TypingRepositoryTest {
     memberRepository.deleteAllInBatch();
   }
 
+  @Disabled
   @Test
   @DisplayName("충분히 많은 데이터가 존재할 때, 총점 기준으로 내림차순하여 상위 50명의 랭킹 정보를 조회할 수 있다.")
   void findTop50WithSequentialRank() {
@@ -67,6 +68,7 @@ class TypingRepositoryTest {
     }
   }
 
+  @Disabled
   @Test
   @DisplayName("월별 랭킹 조회를 했을 때, 모든 데이터의 연월은 현재 날짜의 연월과 같다.")
   void findTop50WithMonthlySequentialRank() {
@@ -113,6 +115,7 @@ class TypingRepositoryTest {
     }
   }
 
+  @Disabled
   @Test
   @DisplayName("타자 결과 정보를 저장했을 때, 해당 유저의 가장 최대 점수에 대한 순위를 반환한다.")
   void findTypingRank() {

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,13 @@
+|===
+|Field|Type|Required|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parameters.snippet
@@ -1,0 +1,8 @@
+|===
+|Param|Required|Description
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,13 @@
+|===
+|Field|Type|Required|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#36 

## 📝 작업 내용

- Spring REST Docs 문서화를 진행하기 위한 의존성 주입
- 문서화를 진행하기에 앞서 중복 코드와 불필요한 문서 내용을 제거하기 위한 Support 추상 메소드 구현 
- 테스트 환경을 위한 Security 파일 작성 및 적용 (요청 csrf 토큰이 Parameter 부분에 나타나는 현상 해결)
- adoc 문서 파일에 적용할 공통 스니펫 문서 작성 (요청 필드, 파라미터 / 응답 필드)
- 각 도메인 Controller 별 테스트하여 생성한 adoc 문서들을 index.html 파일로 생성하는 통합 로직 구현

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

## Reference 
- https://backtony.tistory.com/37
- https://helloworld.kurly.com/blog/spring-rest-docs-guide/
- https://velog.io/@ktf1686/Spring-Spring-REST-Docs-사용하기
