### PR TITLE
Refactor: Phrase 도메인 관련 리팩터링 및 테스트 커버리지 성능 개선 

### DIFF
--- a/src/main/java/dasi/typing/api/service/phrase/PhraseService.java
+++ b/src/main/java/dasi/typing/api/service/phrase/PhraseService.java
@@ -1,5 +1,7 @@
 package dasi.typing.api.service.phrase;
 
+import static dasi.typing.utils.CommonConstant.PHRASE_COUNT;
+
 import dasi.typing.api.controller.phrase.response.PhraseResponse;
 import dasi.typing.domain.phrase.PhraseRepository;
 import java.util.List;
@@ -15,7 +17,7 @@ public class PhraseService {
   private final PhraseRepository phraseRepository;
 
   public List<PhraseResponse> getRandomPhrases() {
-    return phraseRepository.getRandom20Phrases()
+    return phraseRepository.getRandomPhrases(PHRASE_COUNT)
         .stream().map(PhraseResponse::from).toList();
   }
 }

--- a/src/main/java/dasi/typing/domain/phrase/PhraseRepositoryCustom.java
+++ b/src/main/java/dasi/typing/domain/phrase/PhraseRepositoryCustom.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public interface PhraseRepositoryCustom {
 
-  List<Phrase> getRandom20Phrases();
+  List<Phrase> getRandomPhrases(int phraseCount);
 
 }

--- a/src/main/java/dasi/typing/domain/phrase/PhraseRepositoryImpl.java
+++ b/src/main/java/dasi/typing/domain/phrase/PhraseRepositoryImpl.java
@@ -14,14 +14,14 @@ public class PhraseRepositoryImpl implements PhraseRepositoryCustom {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public List<Phrase> getRandom20Phrases() {
+  public List<Phrase> getRandomPhrases(int phraseCount) {
 
     NumberExpression<Double> rand = Expressions.numberTemplate(Double.class, "rand");
 
     return queryFactory
         .selectFrom(phrase)
         .orderBy(rand.asc())
-        .limit(20)
+        .limit(phraseCount)
         .fetch();
   }
 }

--- a/src/main/java/dasi/typing/utils/CommonConstant.java
+++ b/src/main/java/dasi/typing/utils/CommonConstant.java
@@ -30,7 +30,10 @@ public class CommonConstant {
   public static final String USER_INFO_URL = "https://kapi.kakao.com/v1/oidc/userinfo";
 
   // JWT Token Expiration and Refresh Times
-  public static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 3;
-  public static final long TOKEN_REFRESH_TIME = 1000 * 60 * 60 * 24 * 7;
+  public static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 3L;
+  public static final long TOKEN_REFRESH_TIME = 1000 * 60 * 60 * 24 * 7L;
+
+  // Phrase Count for Random Phrases
+  public static final int PHRASE_COUNT = 20;
 
 }

--- a/src/test/java/dasi/typing/api/service/phrase/LuckyMessageServiceTest.java
+++ b/src/test/java/dasi/typing/api/service/phrase/LuckyMessageServiceTest.java
@@ -6,10 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
 class LuckyMessageServiceTest {
 
   @Autowired

--- a/src/test/java/dasi/typing/api/service/phrase/PhraseServiceTest.java
+++ b/src/test/java/dasi/typing/api/service/phrase/PhraseServiceTest.java
@@ -1,0 +1,46 @@
+package dasi.typing.api.service.phrase;
+
+import static dasi.typing.domain.phrase.Lang.KO;
+import static dasi.typing.domain.phrase.LangType.POEM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dasi.typing.api.controller.phrase.response.PhraseResponse;
+import dasi.typing.domain.phrase.Phrase;
+import dasi.typing.domain.phrase.PhraseRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PhraseServiceTest {
+
+  @Test
+  @DisplayName("DB에서 가져온 Phrase 객체 리스트를 PhraseResponse 객체 리스트로 변환하여 반환한다.")
+  void convertPhraseToPhraseResponse(
+      @Autowired PhraseService phraseService,
+      @Autowired PhraseRepository phraseRepository
+  ) {
+
+    // given
+    Phrase phrase = createPhrase();
+    phraseRepository.save(phrase);
+
+    // when
+    List<PhraseResponse> responses = phraseService.getRandomPhrases();
+
+    // then
+    assertThat(responses.getFirst()).isInstanceOf(PhraseResponse.class);
+  }
+
+  private static Phrase createPhrase() {
+    return Phrase.builder()
+        .sentence("test sentence")
+        .title("test title")
+        .author("test author")
+        .lang(KO)
+        .type(POEM)
+        .build();
+  }
+}

--- a/src/test/java/dasi/typing/domain/phrase/PhraseRepositoryTest.java
+++ b/src/test/java/dasi/typing/domain/phrase/PhraseRepositoryTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -21,9 +24,22 @@ class PhraseRepositoryTest {
     phraseRepository.deleteAllInBatch();
   }
 
-  @Test
-  @DisplayName("랜덤으로 20개의 문장들을 조회할 수 있다.")
-  void findRandom20PhraseTest() {
+  private static Stream<Arguments> findRandomPhraseScenarios() {
+    return Stream.of(
+        Arguments.of(1, 1),
+        Arguments.of(3, 3),
+        Arguments.of(5, 5),
+        Arguments.of(10, 10),
+        Arguments.of(15, 15),
+        Arguments.of(20, 20),
+        Arguments.of(25, 25)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("findRandomPhraseScenarios")
+  @DisplayName("파라미터로 주어진 문장의 개수만큼 조회할 수 있다.")
+  void getRandomPhraseTest(int phraseCount, int expectedSize) {
     // given
     List<Phrase> phrases = new ArrayList<>();
     for (int i = 1; i <= 25; i++) {
@@ -34,10 +50,10 @@ class PhraseRepositoryTest {
     // when
     List<Long> allIds = phrases.stream().map(Phrase::getId).toList();
 
-    List<Long> firstResult = phraseRepository.getRandom20Phrases()
+    List<Long> firstResult = phraseRepository.getRandomPhrases(phraseCount)
         .stream().map(Phrase::getId).toList();
 
-    List<Long> secondResult = phraseRepository.getRandom20Phrases()
+    List<Long> secondResult = phraseRepository.getRandomPhrases(phraseCount)
         .stream().map(Phrase::getId).toList();
 
     // then
@@ -46,7 +62,7 @@ class PhraseRepositoryTest {
         .containsAll(secondResult);
 
     assertThat(firstResult)
-        .hasSize(20)
+        .hasSize(expectedSize)
         .hasSameSizeAs(secondResult)
         .isNotEqualTo(secondResult);
   }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#36 #41 

## 📝 작업 내용

- 20개의 문장을 데이터베이스에서 받아오는 메서드를 확장성을 고려하여 가져올 문장의 개수를 파라미터 방식으로 가져오게끔 수정했습니다.
  - 이에 대한 기능 검증 테스트 또한 진행했습니다. 
- Jacoco 테스트 커버리지 성능 결과를 토대로 테스트를 보강하여 성능을 향상시켰습니다.
 
<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

