### PR TITLE
Refactor: Ranking 도메인 관련 테스트 코드 리팩터링 및 테스트 커버리지 성능 개선 

### DIFF
--- a/src/main/java/dasi/typing/api/service/phrase/PhraseService.java
+++ b/src/main/java/dasi/typing/api/service/phrase/PhraseService.java
@@ -1,6 +1,6 @@
 package dasi.typing.api.service.phrase;
 
-import static dasi.typing.utils.CommonConstant.PHRASE_COUNT;
+import static dasi.typing.utils.ConstantUtil.PHRASE_COUNT;
 
 import dasi.typing.api.controller.phrase.response.PhraseResponse;
 import dasi.typing.domain.phrase.PhraseRepository;

--- a/src/test/java/dasi/typing/api/service/ranking/RankingServiceTest.java
+++ b/src/test/java/dasi/typing/api/service/ranking/RankingServiceTest.java
@@ -1,7 +1,5 @@
 package dasi.typing.api.service.ranking;
 
-import static dasi.typing.utils.DateTimeUtil.getMonthEndDate;
-import static dasi.typing.utils.DateTimeUtil.getMonthStartDate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -13,8 +11,6 @@ import dasi.typing.domain.phrase.Phrase;
 import dasi.typing.domain.phrase.PhraseRepository;
 import dasi.typing.domain.typing.Typing;
 import dasi.typing.domain.typing.TypingRepository;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
@@ -45,12 +41,11 @@ class RankingServiceTest {
     memberRepository.deleteAllInBatch();
   }
 
-  private final int RANKING_COUNT = 50;
   private final int USER_COUNT = 100;
 
   @Test
   @DisplayName("50명 이상의 유저 데이터가 있을 때, 점수를 기준으로 내림차순하여 상위 50명의 데이터를 반환할 수 있다.")
-  void getRealTimeRanking() {
+  void getRealTimeRankingTest() {
     // given
     Phrase phrase = createPhrase();
 
@@ -85,7 +80,7 @@ class RankingServiceTest {
 
   @Test
   @DisplayName("50명 이상의 유저 데이터가 있을 때, 현재 날짜에 해당하는 연월에 대해서 최대 50등까지 랭킹 조회를 할 수 있다.")
-  void getMonthlyRanking() {
+  void getMonthlyRankingTest() {
     // given
     Phrase phrase = createPhrase();
 
@@ -99,13 +94,8 @@ class RankingServiceTest {
 
     typingRepository.saveAll(typings);
 
-    LocalDate now = LocalDate.now();
-    LocalDateTime startDate = getMonthStartDate(now);
-    LocalDateTime endDate = getMonthEndDate(now);
-
     // when
-    List<RankingResponse> responses = typingRepository
-        .findMonthlyTopNWithSequentialRank(startDate, endDate, RANKING_COUNT);
+    List<RankingResponse> responses = rankingService.getMonthlyRanking();
 
     // then
     assertTrue(responses.size() <= 50);

--- a/src/test/java/dasi/typing/api/service/typing/TypingServiceTest.java
+++ b/src/test/java/dasi/typing/api/service/typing/TypingServiceTest.java
@@ -1,8 +1,10 @@
 package dasi.typing.api.service.typing;
 
+import static dasi.typing.exception.Code.NOT_EXIST_PHRASE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import dasi.typing.api.controller.typing.request.TypingCreateRequest;
 import dasi.typing.api.service.phrase.LuckyMessageService;
@@ -61,7 +63,7 @@ class TypingServiceTest {
 
   @Test
   @DisplayName("특정 문장에 대한 타자 정보를 생성할 있다.")
-  void createTyping() {
+  void createTypingTest() {
     // given
     Phrase phrase = createPhrase(
         "test sentence",
@@ -99,27 +101,41 @@ class TypingServiceTest {
         .extracting("id", "sentence", "title", "author", "lang", "type")
         .containsExactlyInAnyOrder(
             tuple(
-                savedTyping.getPhrase().getId(), "test sentence", "test title", "test author", Lang.KO, LangType.QUOTE)
+                savedTyping.getPhrase().getId(), "test sentence", "test title", "test author",
+                Lang.KO, LangType.QUOTE)
         );
   }
 
   @Test
-  @DisplayName("존재하지 않는 문장에 대해서 예외가 발생한다.")
-  void notExistPhrase() throws CustomException {
+  @DisplayName("존재하지 않는 문장에 대해서 NOT_EXIST_PHRASE 예외가 발생한다.")
+  void notExistPhraseTest() throws CustomException {
     // given
-    Long phraseId = 999L;
+    String guestId = UUID.randomUUID().toString();
+    AnonymousAuthenticationToken anonymousToken = new AnonymousAuthenticationToken(
+        "guestKey",
+        new GuestPrincipal(guestId),
+        AuthorityUtils.createAuthorityList("GUEST")
+    );
+    SecurityContextHolder.getContext().setAuthentication(anonymousToken);
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-    // when, then
-    assertThatThrownBy(() -> {
-      phraseRepository.findById(phraseId).orElseThrow(
-          () -> new CustomException(Code.NOT_EXIST_PHRASE));
-    }).isInstanceOf(CustomException.class)
-        .hasMessage(Code.NOT_EXIST_PHRASE.getMessage());
+    // when
+    TypingCreateServiceRequest serviceRequest = TypingCreateServiceRequest.builder()
+        .phraseId(999L)
+        .cpm(100)
+        .acc(100)
+        .wpm(100)
+        .maxCpm(120).build();
+
+    // then
+    assertThatThrownBy(() -> typingService.saveTyping(authentication, serviceRequest))
+        .isInstanceOf(CustomException.class)
+        .hasMessage(NOT_EXIST_PHRASE.getMessage());
   }
 
   @Test
   @DisplayName("비회원일 때, 타자 정보 생성 후에 행운의 메시지와 순위를 반환할 수 있다.")
-  void createAnonymousTypingResponse() {
+  void createAnonymousTypingResponseTest() {
     // given
     String guestId = UUID.randomUUID().toString();
     AnonymousAuthenticationToken anonymousToken = new AnonymousAuthenticationToken(
@@ -136,11 +152,11 @@ class TypingServiceTest {
         Lang.KO,
         LangType.QUOTE
     );
-    Phrase savedPhrase = phraseRepository.save(phrase);
 
     // when
-    TypingCreateRequest request = createRequest(savedPhrase);
-    TypingResponse response = typingService.saveTyping(authentication, request.toServiceRequest());
+    Phrase savedPhrase = phraseRepository.save(phrase);
+    TypingCreateServiceRequest serviceRequest = createRequest(savedPhrase).toServiceRequest();
+    TypingResponse response = typingService.saveTyping(authentication, serviceRequest);
 
     // then
     assertThat(response).isNotNull();
@@ -151,8 +167,37 @@ class TypingServiceTest {
   }
 
   @Test
+  @DisplayName("회원이지만 kakaoId 정보가 없는 경우, NOT_EXIST_MEMBER 예외가 발생한다.")
+  void createTypingWithMissingKakaoIdTest() {
+    // given
+    List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("USER");
+    UsernamePasswordAuthenticationToken authenticationToken =
+        new UsernamePasswordAuthenticationToken("000000000", null, authorities);
+    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    Phrase phrase = createPhrase(
+        "test sentence",
+        "test title",
+        "test author",
+        Lang.KO,
+        LangType.QUOTE
+    );
+
+    // when
+    Phrase savedPhrase = phraseRepository.save(phrase);
+    TypingCreateServiceRequest serviceRequest = createRequest(savedPhrase).toServiceRequest();
+    Code expectedErrorCode = assertThrows(CustomException.class, () -> {
+      typingService.saveTyping(authentication, serviceRequest);
+    }).getErrorCode();
+
+    // then
+    assertThat(expectedErrorCode).isEqualTo(Code.NOT_EXIST_MEMBER);
+  }
+
+  @Test
   @DisplayName("회원일 때, 타자 정보 생성 후에 행운의 메시지와 순위를 반환할 수 있다.")
-  void createUserTypingResponse() {
+  void createUserTypingResponseTest() {
     // given
     String kakaoId = "000000000";
     Member member = createMember(kakaoId, "test nickname");

--- a/src/test/java/dasi/typing/domain/phrase/PhraseRepositoryTest.java
+++ b/src/test/java/dasi/typing/domain/phrase/PhraseRepositoryTest.java
@@ -42,7 +42,7 @@ class PhraseRepositoryTest {
   void getRandomPhraseTest(int phraseCount, int expectedSize) {
     // given
     List<Phrase> phrases = new ArrayList<>();
-    for (int i = 1; i <= 25; i++) {
+    for (int i = 1; i <= 30; i++) {
       phrases.add(createPhrase(String.valueOf(i), "문장 " + i, "작가 " + i));
     }
     phraseRepository.saveAll(phrases);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#36 #41 

## 📝 작업 내용

- 사용되지 않는 불필요한 import문 및 변수를 제거했습니다.
- Ranking 도메인 관련 테스트 코드를 리팩터링했습니다.
  - Service 레이어에서 Repository 레이어 테스트 진행하던 것을 Service 통합 테스트로 수정했습니다.
- Jacoco 테스트 커버리지 성능 결과를 토대로 테스트를 보강하여 성능을 향상시켰습니다.

## 📍 개선 사항
- Jacoco 테스트 커버리지 성능을 향상시켰습니다.
  - 구문 커버리지 성능을 2% 향상시켰습니다. (72% -> 74%)

### 수정 전
![image](https://github.com/user-attachments/assets/e0a5b521-be56-454b-9a00-863238ca88e4)

### 수정 후 
![image](https://github.com/user-attachments/assets/e701ce20-f146-460c-81fd-0482253b5ac1)

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>